### PR TITLE
Mention provider version requirement

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # random\_password
 
+~> **Note:** Requires random provider version >= 2.2.0
+
 Identical to [random_string](string.html) with the exception that the
 result is treated as sensitive and, thus, not displayed in console output.
 


### PR DESCRIPTION
Since the random provider is not automatically updated to 2.2.0, it's confusing not to have mentioned that to be able to use random_password you need at least this version.