### PR TITLE
Add a hash to random_password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.11.0
+	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 )

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/random/resource_password.go
+++ b/random/resource_password.go
@@ -1,15 +1,38 @@
 package random
 
 import (
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func resourcePassword() *schema.Resource {
+	passwordSchema := stringSchemaV1(true)
+	passwordSchema["bcrypt_hash"] = &schema.Schema{
+		Type:      schema.TypeString,
+		Computed:  true,
+		Sensitive: true,
+	}
+
+	create := func(d *schema.ResourceData, meta interface{}) error {
+		if err := createStringFunc(true)(d, meta); err != nil {
+			return err
+		}
+		if d.Get("bcrypt_hash") == "" {
+			hash, err := bcrypt.GenerateFromPassword([]byte(d.Get("result").(string)), bcrypt.DefaultCost)
+			if err != nil {
+				return errwrap.Wrapf("error hashing random bytes: {{err}}", err)
+			}
+			d.Set("bcrypt_hash", string(hash))
+		}
+		return nil
+	}
+
 	return &schema.Resource{
-		Create: createStringFunc(true),
+		Create: create,
 		Read:   readNil,
 		Delete: schema.RemoveFromState,
-		Schema: stringSchemaV1(true),
+		Schema: passwordSchema,
 		Importer: &schema.ResourceImporter{
 			State: importStringFunc(true),
 		},

--- a/vendor/golang.org/x/crypto/openpgp/elgamal/elgamal.go
+++ b/vendor/golang.org/x/crypto/openpgp/elgamal/elgamal.go
@@ -76,7 +76,9 @@ func Encrypt(random io.Reader, pub *PublicKey, msg []byte) (c1, c2 *big.Int, err
 // Bleichenbacher, Advances in Cryptology (Crypto '98),
 func Decrypt(priv *PrivateKey, c1, c2 *big.Int) (msg []byte, err error) {
 	s := new(big.Int).Exp(c1, priv.X, priv.P)
-	s.ModInverse(s, priv.P)
+	if s.ModInverse(s, priv.P) == nil {
+		return nil, errors.New("elgamal: invalid private key")
+	}
 	s.Mul(s, c2)
 	s.Mod(s, priv.P)
 	em := s.Bytes()

--- a/vendor/golang.org/x/crypto/openpgp/packet/encrypted_key.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/encrypted_key.go
@@ -5,6 +5,7 @@
 package packet
 
 import (
+	"crypto"
 	"crypto/rsa"
 	"encoding/binary"
 	"io"
@@ -78,8 +79,9 @@ func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
 	// padding oracle attacks.
 	switch priv.PubKeyAlgo {
 	case PubKeyAlgoRSA, PubKeyAlgoRSAEncryptOnly:
-		k := priv.PrivateKey.(*rsa.PrivateKey)
-		b, err = rsa.DecryptPKCS1v15(config.Random(), k, padToKeySize(&k.PublicKey, e.encryptedMPI1.bytes))
+		// Supports both *rsa.PrivateKey and crypto.Decrypter
+		k := priv.PrivateKey.(crypto.Decrypter)
+		b, err = k.Decrypt(config.Random(), padToKeySize(k.Public().(*rsa.PublicKey), e.encryptedMPI1.bytes), nil)
 	case PubKeyAlgoElGamal:
 		c1 := new(big.Int).SetBytes(e.encryptedMPI1.bytes)
 		c2 := new(big.Int).SetBytes(e.encryptedMPI2.bytes)

--- a/vendor/golang.org/x/crypto/openpgp/packet/private_key.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/private_key.go
@@ -31,7 +31,7 @@ type PrivateKey struct {
 	encryptedData []byte
 	cipher        CipherFunction
 	s2k           func(out, in []byte)
-	PrivateKey    interface{} // An *{rsa|dsa|ecdsa}.PrivateKey or a crypto.Signer.
+	PrivateKey    interface{} // An *{rsa|dsa|ecdsa}.PrivateKey or crypto.Signer/crypto.Decrypter (Decryptor RSA only).
 	sha1Checksum  bool
 	iv            []byte
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -252,7 +252,8 @@ go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
-# golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
+# golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5

--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -12,6 +12,7 @@ description: |-
 
 Identical to [random_string](string.html) with the exception that the
 result is treated as sensitive and, thus, _not_ displayed in console output.
+It also adds the additional field `bcrypt_hash`.
 
 ~> **Note:** All attributes including the generated password will be stored in
 the raw state as plain-text. [Read more about sensitive data in
@@ -36,6 +37,7 @@ resource "aws_db_instance" "example" {
   password = random_password.password.result
 }
 ```
+
 ## Import
 
 Random Password can be imported by specifying the value of the string:
@@ -43,3 +45,16 @@ Random Password can be imported by specifying the value of the string:
 ```
 terraform import random_password.password securepassword
 ```
+
+## Argument Reference
+
+random_password has the same arguments as listed in [random_string](string.html).
+
+## Attribute Reference
+
+The following attribute is added to [random_string](string.html):
+
+* `bcrypt_hash` - (string) The random string hashed with the bcrypt adaptive
+  hashing algorithm. Hashing with bcrypt always produces a different result
+  (even for the same input), which can be annoying to use. This attribute will
+  only change when another random string is generated.


### PR DESCRIPTION
Hi,

## Problem

We have experienced cases where we need to hash a password with `bcrypt`. The `bcrypt` function in terraform always generates a new hash on every run (which is according to spec). However, this can be annoying to use.
For example:

```hcl
resource "random_password" "admin_password" {
  length  = 20
  special = true
}

# store the password in vault
resource "vault_generic_secret" "password" {
  path         = "/passwords/mypassword" 
  disable_read = true

  data_json = <<EOT
{
  "password": "${random_password.password.result}",
  "bcrypt_hash": "${bcrypt(random_password.password.result)}" 
}
EOT
}
```

In this example, `vault_generic_secret.password` gets changed on every run. There is also no way (at least no obvious one) to work around this problem - `ignore_changes` cannot be used when this kind of interpolation is required.

## Solution

The solution to this is to add a `bcrypt_hash` field to the `random_password` resource. This always returns the same hash (as it is stored in the terraform state), unless the password (random string) itself is changed.
With that, the above usecase can be done just by doing

```hcl
  data_json = <<EOT
{
  "password": "${random_password.password.result}",
  "bcrypt_hash": "${random_password.password.bcrypt_hash)}" 
}
EOT
```