### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ NEW FEATURES:
 
 NOTES:
 
-* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#76](https://github.com/terraform-providers/terraform-provider-random/issues/76))
+* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#76](https://github.com/hashicorp/terraform-provider-random/issues/76))
 
 ## 2.2.0 (August 08, 2019)
 
 NEW FEATURES:
 
-* `random_password` is similar to `random_string` but is marked sensitive for logs and output [[#52](https://github.com/terraform-providers/terraform-provider-random/issues/52)] 
+* `random_password` is similar to `random_string` but is marked sensitive for logs and output [[#52](https://github.com/hashicorp/terraform-provider-random/issues/52)]
 
 ## 2.1.2 (April 30, 2019)
 
@@ -37,53 +37,53 @@ IMPROVEMENTS:
 ## 2.0.0 (August 15, 2018)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
-* `random_string`: set the ID for random_string resources to "none". Any terraform configuration referring to `random_string.foo.id` will need to be updated to reference `random_string.foo.result` ([#17](https://github.com/terraform-providers/terraform-provider-random/issues/17))
+* `random_string`: set the ID for random_string resources to "none". Any terraform configuration referring to `random_string.foo.id` will need to be updated to reference `random_string.foo.result` ([#17](https://github.com/hashicorp/terraform-provider-random/issues/17))
 
 NEW FEATURES:
 
-* `random_uuid` generates random uuid string that is intended to be used as unique identifiers for other resources ([#38](https://github.com/terraform-providers/terraform-provider-random/issues/38))
+* `random_uuid` generates random uuid string that is intended to be used as unique identifiers for other resources ([#38](https://github.com/hashicorp/terraform-provider-random/issues/38))
 
 BUG FIXES: 
-* Use UnixNano() instead of Unix() for the current time seed in NewRand() ([#27](https://github.com/terraform-providers/terraform-provider-random/issues/27))
+* Use UnixNano() instead of Unix() for the current time seed in NewRand() ([#27](https://github.com/hashicorp/terraform-provider-random/issues/27))
 * `random_shuffle`: if `random_shuffle` is given an empty list, it will return an empty list
 
 IMPROVEMENTS:
 
-* Replace ReadPet function in `resource_pet` with schema.Noop ([#34](https://github.com/terraform-providers/terraform-provider-random/issues/34))
+* Replace ReadPet function in `resource_pet` with schema.Noop ([#34](https://github.com/hashicorp/terraform-provider-random/issues/34))
 
 ## 1.3.1 (May 22, 2018)
 
 BUG FIXES:
 
-* Add migration and new schema version for `resource_string` ([#29](https://github.com/terraform-providers/terraform-provider-random/issues/29))
+* Add migration and new schema version for `resource_string` ([#29](https://github.com/hashicorp/terraform-provider-random/issues/29))
 
 ## 1.3.0 (May 21, 2018)
 
 BUG FIXES:
 
-* `random_integer` now supports update ([#25](https://github.com/terraform-providers/terraform-provider-random/issues/25))
+* `random_integer` now supports update ([#25](https://github.com/hashicorp/terraform-provider-random/issues/25))
 
 IMPROVEMENTS:
 
-* Add optional minimum character constraints to `random_string` ([#22](https://github.com/terraform-providers/terraform-provider-random/issues/22))
+* Add optional minimum character constraints to `random_string` ([#22](https://github.com/hashicorp/terraform-provider-random/issues/22))
 
 ## 1.2.0 (April 03, 2018)
 
 NEW FEATURES:
 
-* `random_integer` and `random_id` are now importable. ([#20](https://github.com/terraform-providers/terraform-provider-random/issues/20))
+* `random_integer` and `random_id` are now importable. ([#20](https://github.com/hashicorp/terraform-provider-random/issues/20))
 
 ## 1.1.0 (December 01, 2017)
 
 NEW FEATURES:
 
-* `random_integer` resource generates a single integer within a given range. ([#12](https://github.com/terraform-providers/terraform-provider-random/issues/12))
+* `random_integer` resource generates a single integer within a given range. ([#12](https://github.com/hashicorp/terraform-provider-random/issues/12))
 
 ## 1.0.0 (September 15, 2017)
 
 NEW FEATURES:
 
-* `random_string` resource generates random strings of a given length consisting of letters, digits and symbols. ([#5](https://github.com/terraform-providers/terraform-provider-random/issues/5))
+* `random_string` resource generates random strings of a given length consisting of letters, digits and symbols. ([#5](https://github.com/hashicorp/terraform-provider-random/issues/5))
 
 ## 0.1.0 (June 21, 2017)
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-random`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-random`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-random
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-random
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-random
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-random
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-random
+module github.com/hashicorp/terraform-provider-random
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-random/random"
+	"github.com/hashicorp/terraform-provider-random/random"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-random\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-random\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
`terraform-provider-random` has been moved to the `hashicorp`
organization.