### PR TITLE
Update with useful value

### DIFF
--- a/website/docs/r/password.html.md
+++ b/website/docs/r/password.html.md
@@ -25,7 +25,7 @@ This resource *does* use a cryptographic random number generator.
 resource "random_password" "password" {
   length = 16
   special = true
-  override_special = "_%@"
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 resource "aws_db_instance" "example" {


### PR DESCRIPTION
You can't use the "@" symbol in a master password.

https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

Search "MasterUserPassword" you'll find:

> The password for the master user. The password can include any printable ASCII character except "/", """, or "@".