### PR TITLE
use random_integer keepers in resource

### DIFF
--- a/website/docs/r/integer.html.md
+++ b/website/docs/r/integer.html.md
@@ -31,7 +31,7 @@ resource "random_integer" "priority" {
 }
 
 resource "aws_alb_listener_rule" "main" {
-  listener_arn = "${var.listener_arn}"
+  listener_arn = "${random_integer.priority.keepers.listener_arn}"
   priority     = "${random_integer.priority.result}"
 
   action {


### PR DESCRIPTION
According to the random provider documentation, you should use the keeper property such that the resource remain the same until new random values are desired.