### PR TITLE
Allow override num, lower, upper characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 3.0.1 (Unreleased)
+## 3.0.1 (January 12, 2021)
 
 BUG FIXES:
 
-* `resource_integer`: Integers in state that do not cleanly fit into float64s no longer lose their precision [GH-132]
+* `resource_integer`: Integers in state that do not cleanly fit into float64s no longer lose their precision ([#132](https://github.com/terraform-providers/terraform-provider-random/issues/132))
 
 ## 3.0.0 (October 09, 2020)
 

--- a/internal/provider/string.go
+++ b/internal/provider/string.go
@@ -94,6 +94,27 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 			ForceNew:    true,
 		},
 
+		"override_num": {
+			Description: "Supply your own list of numeric characters to use for string generation.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+		},
+
+		"override_lower": {
+			Description: "Supply your own list of lowercase alphabet characters to use for string generation.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+		},
+
+		"override_upper": {
+			Description: "Supply your own list of uppercase alphabet characters to use for string generation.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+		},
+
 		"override_special": {
 			Description: "Supply your own list of special characters to use for string generation.  This " +
 				"overrides the default character list in the special argument.  The `special` argument must " +
@@ -114,9 +135,9 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 
 func createStringFunc(sensitive bool) func(d *schema.ResourceData, meta interface{}) error {
 	return func(d *schema.ResourceData, meta interface{}) error {
-		const numChars = "0123456789"
-		const lowerChars = "abcdefghijklmnopqrstuvwxyz"
-		const upperChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		var numChars = "0123456789"
+		var lowerChars = "abcdefghijklmnopqrstuvwxyz"
+		var upperChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		var specialChars = "!@#$%&*()-_=+[]{}<>:?"
 
 		length := d.Get("length").(int)
@@ -128,7 +149,22 @@ func createStringFunc(sensitive bool) func(d *schema.ResourceData, meta interfac
 		minNumeric := d.Get("min_numeric").(int)
 		special := d.Get("special").(bool)
 		minSpecial := d.Get("min_special").(int)
+		overrideNum := d.Get("override_num").(string)
+		overrideLower := d.Get("override_lower").(string)
+		overrideUpper := d.Get("override_upper").(string)
 		overrideSpecial := d.Get("override_special").(string)
+
+		if overrideNum != "" {
+			numChars = overrideNum
+		}
+
+		if overrideLower != "" {
+			lowerChars = overrideLower
+		}
+
+		if overrideUpper != "" {
+			upperChars = overrideUpper
+		}
 
 		if overrideSpecial != "" {
 			specialChars = overrideSpecial

--- a/website/docs/r/string.html.md
+++ b/website/docs/r/string.html.md
@@ -58,6 +58,15 @@ The following arguments are supported:
 * `min_special` - (Optional) (default 0) Minimum number of special characters
   in random string.
 
+* `override_num` - (Optional) Supply your own list of numeric characters to use
+  for string generation.
+
+* `override_lower` - (Optional) Supply your own list of lowercase alphabet
+  characters to use for string generation.
+
+* `override_upper` (Optional) Supply your own list of uppercase alphabet
+  characters to use for string generation.
+
 * `override_special` - (Optional) Supply your own list of special characters to
   use for string generation.  This overrides the default character list in the special
   argument.  The special argument must still be set to true for any overwritten


### PR DESCRIPTION
Allow overrides to all characters, to create passwords without ambiguous characters like `O0oIl`.