### PR TITLE
feat: string and password import with settings

### DIFF
--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -22,6 +22,15 @@ resource "random_password" "password" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
+resource "random_password" "test" {
+  length  = 6
+  special = false
+  keepers = {
+    blah = "dibla"
+    key  = "value"
+  }
+}
+
 resource "aws_db_instance" "example" {
   instance_class    = "db.t3.micro"
   allocated_storage = 64
@@ -61,6 +70,11 @@ resource "aws_db_instance" "example" {
 Import is supported using the following syntax:
 
 ```shell
-# Random Password can be imported by specifying the value of the string:
-terraform import random_password.password securepassword
+# Random Password can be imported by specifying the value of the string alongside the resource attributes.
+terraform import random_password.password "password keepers=nil,length=8,special=true,upper=true,lower=true,number=true,min_numeric=0,min_upper=0,min_lower=0,min_special=0,override_special=_%@"
+
+# Note: `override_special` should be the last specified key if any
+
+# Note: When importing keepers, a jsonString should be specified without spaces
+terraform import random_password.test "234567 length=6,special=false,keepers=={\"bla\":\"dibla\",\"key\":\"value\"}"
 ```

--- a/docs/resources/string.md
+++ b/docs/resources/string.md
@@ -58,4 +58,15 @@ Import is supported using the following syntax:
 ```shell
 # Strings can be imported by just specifying the value of the string:
 terraform import random_string.test test
+
+# Strings can be imported by just specifying the value of the string alongside the resource attributes.
+terraform import random_string.test "test length=4"
+
+# Strings can be imported by specifying the value of the string alongside the resource attributes.
+terraform import random_string.test "test keepers=nil,length=4,special=true,upper=true,lower=true,number=true,min_numeric=0,min_upper=0,min_lower=0,min_special=0,override_special=_%@"
+
+# Note: `override_special` should be the last specified key if any
+
+# Note: When importing keepers, a jsonString should be specified without spaces
+terreform import random_string.test "234567 length=6,special=false,keepers=={\"bla\":\"dibla\",\"key\":\"value\"}"
 ```

--- a/examples/resources/random_password/import.sh
+++ b/examples/resources/random_password/import.sh
@@ -1,2 +1,7 @@
-# Random Password can be imported by specifying the value of the string:
-terraform import random_password.password securepassword
+# Random Password can be imported by specifying the value of the string alongside the resource attributes.
+terraform import random_password.password "password keepers=nil,length=8,special=true,upper=true,lower=true,number=true,min_numeric=0,min_upper=0,min_lower=0,min_special=0,override_special=_%@"
+
+# Note: `override_special` should be the last specified key if any
+
+# Note: When importing keepers, a jsonString should be specified without spaces
+terraform import random_password.test "234567 length=6,special=false,keepers=={\"bla\":\"dibla\",\"key\":\"value\"}"

--- a/examples/resources/random_password/resource.tf
+++ b/examples/resources/random_password/resource.tf
@@ -4,6 +4,15 @@ resource "random_password" "password" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
+resource "random_password" "test" {
+  length  = 6
+  special = false
+  keepers = {
+    blah = "dibla"
+    key  = "value"
+  }
+}
+
 resource "aws_db_instance" "example" {
   instance_class    = "db.t3.micro"
   allocated_storage = 64

--- a/examples/resources/random_string/import.sh
+++ b/examples/resources/random_string/import.sh
@@ -1,2 +1,13 @@
 # Strings can be imported by just specifying the value of the string:
 terraform import random_string.test test
+
+# Strings can be imported by just specifying the value of the string alongside the resource attributes.
+terraform import random_string.test "test length=4"
+
+# Strings can be imported by specifying the value of the string alongside the resource attributes.
+terraform import random_string.test "test keepers=nil,length=4,special=true,upper=true,lower=true,number=true,min_numeric=0,min_upper=0,min_lower=0,min_special=0,override_special=_%@"
+
+# Note: `override_special` should be the last specified key if any
+
+# Note: When importing keepers, a jsonString should be specified without spaces
+terreform import random_string.test "234567 length=6,special=false,keepers=={\"bla\":\"dibla\",\"key\":\"value\"}"

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -2,10 +2,11 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 type customLens struct {
@@ -91,6 +92,60 @@ func TestAccResourceStringErrors(t *testing.T) {
 	})
 }
 
+func TestAccResourcePassword_import_simple(t *testing.T) {
+	t.Parallel()
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRandomPasswordImportSimple,
+			},
+			{
+				ResourceName:            "random_password.bladibla",
+				ImportStateId:           "password upper=false,length=8,number=false,special=false,keepers={\"bla\":\"dibla\",\"key\":\"value\"}",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"result"},
+				ImportStateCheck:        testAccResourcePasswordImportCheck("random_password.bladibla", "password"),
+			},
+		},
+	})
+}
+
+func TestAccResourcePassword_import_stronger(t *testing.T) {
+	t.Parallel()
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRandomPasswordImportStronger,
+			},
+			{
+				ResourceName:            "random_password.bladibla_strong",
+				ImportStateId:           "{^%^^]!(]&&([{%%&)]!&)][(^^!(&)) length=32,min_special=32,override_special=_!@#$%^&*()[]{}",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"result"},
+				ImportStateCheck:        testAccResourcePasswordImportCheck("random_password.bladibla_strong", "{^%^^]!(]&&([{%%&)]!&)][(^^!(&))"),
+			},
+		},
+	})
+}
+
+func testAccResourcePasswordImportCheck(id string, expected string) resource.ImportStateCheckFunc {
+	return func(instanceSates []*terraform.InstanceState) error {
+		result := instanceSates[0]
+		if val, ok := result.Attributes["result"]; ok {
+			if val != expected {
+				return fmt.Errorf("id %s: result %v is not expected. Expecting %v", id, val, expected)
+			}
+		}
+		return nil
+	}
+}
+
 const (
 	testAccResourceStringBasic = `
 resource "random_string" "basic" {
@@ -122,6 +177,36 @@ resource "random_string" "invalid_length" {
 	testAccResourceStringLengthTooShortConfig = `
 resource "random_string" "invalid_length" {
   length = 0
+}`
+	testRandomPasswordImportSimple = `
+resource "random_password" "bladibla" {
+  keepers          = {
+	bla = "dibla"
+    key = "value"
+  }
+  length           = 8
+  special          = false
+  upper            = false
+  lower            = true
+  number           = false
+  min_numeric      = 0
+  min_upper        = 0
+  min_lower        = 0
+  min_special      = 0
+  override_special = ""
+}`
+	testRandomPasswordImportStronger = `
+resource "random_password" "bladibla_strong" {
+  length           = 32
+  special          = true
+  upper            = true
+  lower            = true
+  number           = true
+  min_numeric      = 0
+  min_upper        = 0
+  min_lower        = 0
+  min_special      = 32
+  override_special = "_!@#$%^&*()[]{}"
 }`
 )
 


### PR DESCRIPTION
This PR add the ability to import `random_string` and `random_password` with their settings. 
Settings might be specified in the resource address while importing and alter a set of default settings.

This is to avoid the re-creation of random string/password after import, settings being `null`.

Despite [this workaround](https://github.com/hashicorp/terraform-provider-random/issues/106#issuecomment-692568119), I believe that being able to specify  resource settings is a better approach.

This PR resolves #106 #119 

A resource `address` could be either a single string, then default settings are applied or a string with a set of comma separated key=value

eg:

```
bladibla length=8,special=false
```

will import the resource with `result` = `bladibla` and `length` of `8` and `special` set to `false`

Full example:

```hcl
resource "random_password" "test" {
  keepers = {
    bla: "dibla"
    key: "value"
  }
  length           = 6
  special          = false
  upper            = true
  lower            = true
  number           = true
  min_numeric      = 0
  min_upper        = 0
  min_lower        = 0
  min_special      = 0
  override_special = ""
}
```

```
~# terraform import random_password.test "234567 length=6,special=false,keepers={\"bla\":\"dibla\",\"key\":\"value\"}"                                                                                         
random_password.test: Importing from ID "234567 length=6,special=false,keepers={\"bla\":\"dibla\",\"key\":\"value\"}"...
random_password.test: Import prepared!
  Prepared random_password for import
random_password.test: Refreshing state... [id=none]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

```

Then with `terraform plan`

```
~# terraform plan                                                                                                                                                                                      
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

random_password.test: Refreshing state... [id=none]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.

```