### PR TITLE
.github/workflows: Add 'go generate' testing for differences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,18 @@ jobs:
       run: |
         go build -v .
 
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.16'
+      - uses: actions/checkout@v3
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
 # run acceptance tests in a matrix with Terraform core versions
   test:

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -19,7 +19,7 @@ This resource *does* use a cryptographic random number generator.
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 resource "aws_db_instance" "example" {
@@ -41,15 +41,15 @@ resource "aws_db_instance" "example" {
 ### Optional
 
 - **keepers** (Map of String) Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider documentation](../index.html) for more information.
-- **lower** (Boolean) Include lowercase alphabet characters in the result.
-- **min_lower** (Number) Minimum number of lowercase alphabet characters in the result.
-- **min_numeric** (Number) Minimum number of numeric characters in the result.
-- **min_special** (Number) Minimum number of special characters in the result.
-- **min_upper** (Number) Minimum number of uppercase alphabet characters in the result.
-- **number** (Boolean) Include numeric characters in the result.
+- **lower** (Boolean) Include lowercase alphabet characters in the result. Default value is `true`.
+- **min_lower** (Number) Minimum number of lowercase alphabet characters in the result. Default value is `0`.
+- **min_numeric** (Number) Minimum number of numeric characters in the result. Default value is `0`.
+- **min_special** (Number) Minimum number of special characters in the result. Default value is `0`.
+- **min_upper** (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
+- **number** (Boolean) Include numeric characters in the result. Default value is `true`.
 - **override_special** (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
-- **special** (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`
-- **upper** (Boolean) Include uppercase alphabet characters in the result.
+- **special** (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.
+- **upper** (Boolean) Include uppercase alphabet characters in the result. Default value is `true`.
 
 ### Read-Only
 

--- a/docs/resources/string.md
+++ b/docs/resources/string.md
@@ -37,13 +37,13 @@ resource "random_string" "random" {
 
 - **keepers** (Map of String) Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider documentation](../index.html) for more information.
 - **lower** (Boolean) Include lowercase alphabet characters in the result. Default value is `true`.
-- **min_lower** (Number) Minimum number of lowercase alphabet characters in the result. Default value is `true`.
+- **min_lower** (Number) Minimum number of lowercase alphabet characters in the result. Default value is `0`.
 - **min_numeric** (Number) Minimum number of numeric characters in the result. Default value is `0`.
 - **min_special** (Number) Minimum number of special characters in the result. Default value is `0`.
 - **min_upper** (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
 - **number** (Boolean) Include numeric characters in the result. Default value is `true`.
 - **override_special** (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
-- **special** (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`
+- **special** (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.
 - **upper** (Boolean) Include uppercase alphabet characters in the result. Default value is `true`.
 
 ### Read-Only

--- a/internal/provider/string.go
+++ b/internal/provider/string.go
@@ -36,7 +36,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"special": {
-			Description: "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`",
+			Description: "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
@@ -44,7 +44,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"upper": {
-			Description: "Include uppercase alphabet characters in the result.",
+			Description: "Include uppercase alphabet characters in the result. Default value is `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
@@ -52,7 +52,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"lower": {
-			Description: "Include lowercase alphabet characters in the result.",
+			Description: "Include lowercase alphabet characters in the result. Default value is `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
@@ -60,7 +60,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"number": {
-			Description: "Include numeric characters in the result.",
+			Description: "Include numeric characters in the result. Default value is `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
@@ -68,7 +68,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"min_numeric": {
-			Description: "Minimum number of numeric characters in the result.",
+			Description: "Minimum number of numeric characters in the result. Default value is `0`.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,
@@ -76,7 +76,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"min_upper": {
-			Description: "Minimum number of uppercase alphabet characters in the result.",
+			Description: "Minimum number of uppercase alphabet characters in the result. Default value is `0`.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,
@@ -84,7 +84,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"min_lower": {
-			Description: "Minimum number of lowercase alphabet characters in the result.",
+			Description: "Minimum number of lowercase alphabet characters in the result. Default value is `0`.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,
@@ -92,7 +92,7 @@ func stringSchemaV1(sensitive bool) map[string]*schema.Schema {
 		},
 
 		"min_special": {
-			Description: "Minimum number of special characters in the result.",
+			Description: "Minimum number of special characters in the result. Default value is `0`.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,


### PR DESCRIPTION
Since this project is already using `terraform-plugin-docs`, there can be differences between the source schema/markdown and generated documentation. This will ensure those differences are caught during CI.

Further documentation testing is possible via `tfproviderdocs`, however this at least covers a common issue with documentation generation.