### PR TITLE
Clean-up Tests

### DIFF
--- a/internal/provider/resource_id_test.go
+++ b/internal/provider/resource_id_test.go
@@ -27,17 +27,31 @@ func TestAccResourceID(t *testing.T) {
 						b64StdLen: 8,
 						hexLen:    8,
 					}),
-					testAccResourceIDCheck("random_id.bar", &idLens{
-						b64UrlLen: 12,
-						b64StdLen: 14,
-						hexLen:    14,
-					}),
 				),
 			},
 			{
 				ResourceName:      "random_id.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceID_importWithPrefix(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceIDConfigWithPrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceIDCheck("random_id.bar", &idLens{
+						b64UrlLen: 12,
+						b64StdLen: 14,
+						hexLen:    14,
+					}),
+				),
 			},
 			{
 				ResourceName:        "random_id.bar",
@@ -85,8 +99,9 @@ const (
 	testAccResourceIDConfig = `
 resource "random_id" "foo" {
   byte_length = 4
-}
+}`
 
+	testAccResourceIDConfigWithPrefix = `
 resource "random_id" "bar" {
   byte_length = 4
   prefix      = "cloud-"

--- a/internal/provider/resource_id_test.go
+++ b/internal/provider/resource_id_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 type idLens struct {
-	b64Len    int
 	b64UrlLen int
 	b64StdLen int
 	hexLen    int
@@ -24,13 +23,11 @@ func TestAccResourceID(t *testing.T) {
 				Config: testAccResourceIDConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceIDCheck("random_id.foo", &idLens{
-						b64Len:    6,
 						b64UrlLen: 6,
 						b64StdLen: 8,
 						hexLen:    8,
 					}),
 					testAccResourceIDCheck("random_id.bar", &idLens{
-						b64Len:    12,
 						b64UrlLen: 12,
 						b64StdLen: 14,
 						hexLen:    14,

--- a/internal/provider/resource_shuffle_test.go
+++ b/internal/provider/resource_shuffle_test.go
@@ -9,39 +9,95 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccResourceShuffle(t *testing.T) {
+// These results are current as of Go 1.6. The Go
+// "rand" package does not guarantee that the random
+// number generator will generate the same results
+// forever, but the maintainers endeavor not to change
+// it gratuitously.
+// These tests allow us to detect such changes and
+// document them when they arise, but the docs for this
+// resource specifically warn that results are not
+// guaranteed consistent across Terraform releases.
+func TestAccResourceShuffleDefault(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceShuffleConfig,
+				Config: testAccResourceShuffleConfigDefault,
 				Check: resource.ComposeTestCheckFunc(
-					// These results are current as of Go 1.6. The Go
-					// "rand" package does not guarantee that the random
-					// number generator will generate the same results
-					// forever, but the maintainers endeavor not to change
-					// it gratuitously.
-					// These tests allow us to detect such changes and
-					// document them when they arise, but the docs for this
-					// resource specifically warn that results are not
-					// guaranteed consistent across Terraform releases.
 					testAccResourceShuffleCheck(
 						"random_shuffle.default_length",
 						[]string{"a", "c", "b", "e", "d"},
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceShuffleShorter(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceShuffleConfigShorter,
+				Check: resource.ComposeTestCheckFunc(
 					testAccResourceShuffleCheck(
 						"random_shuffle.shorter_length",
 						[]string{"a", "c", "b"},
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceShuffleLonger(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceShuffleConfigLonger,
+				Check: resource.ComposeTestCheckFunc(
 					testAccResourceShuffleCheck(
 						"random_shuffle.longer_length",
 						[]string{"a", "c", "b", "e", "d", "a", "e", "d", "c", "b", "a", "b"},
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceShuffleEmpty(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceShuffleConfigEmpty,
+				Check: resource.ComposeTestCheckFunc(
 					testAccResourceShuffleCheck(
 						"random_shuffle.empty_length",
 						[]string{},
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceShuffleOne(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceShuffleConfigOne,
+				Check: resource.ComposeTestCheckFunc(
 					testAccResourceShuffleCheck(
 						"random_shuffle.one_length",
 						[]string{"a"},
@@ -81,30 +137,42 @@ func testAccResourceShuffleCheck(id string, wants []string) resource.TestCheckFu
 	}
 }
 
-const testAccResourceShuffleConfig = `
+const (
+	testAccResourceShuffleConfigDefault = `
 resource "random_shuffle" "default_length" {
     input = ["a", "b", "c", "d", "e"]
     seed = "-"
-}
+}`
+
+	testAccResourceShuffleConfigShorter = `
 resource "random_shuffle" "shorter_length" {
     input = ["a", "b", "c", "d", "e"]
     seed = "-"
     result_count = 3
 }
+`
+
+	testAccResourceShuffleConfigLonger = `
 resource "random_shuffle" "longer_length" {
     input = ["a", "b", "c", "d", "e"]
     seed = "-"
     result_count = 12
 }
+`
+
+	testAccResourceShuffleConfigEmpty = `
 resource "random_shuffle" "empty_length" {
     input = []
     seed = "-"
     result_count = 12
 }
+`
+
+	testAccResourceShuffleConfigOne = `
 resource "random_shuffle" "one_length" {
     input = ["a"]
     seed = "-"
     result_count = 1
 }
-
 `
+)

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -12,7 +12,7 @@ type customLens struct {
 	customLen int
 }
 
-func TestAccResourceStringBasic(t *testing.T) {
+func TestAccResourceString(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
@@ -74,12 +74,28 @@ func TestAccResourceStringMin(t *testing.T) {
 	})
 }
 
+func TestAccResourceStringErrors(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceStringInvalidConfig,
+				ExpectError: regexp.MustCompile(`.*length \(2\) must be >= min_upper \+ min_lower \+ min_numeric \+ min_special \(3\)`),
+			},
+			{
+				Config:      testAccResourceStringLengthTooShortConfig,
+				ExpectError: regexp.MustCompile(`.*expected length to be at least \(1\), got 0`),
+			},
+		},
+	})
+}
+
 const (
 	testAccResourceStringBasic = `
 resource "random_string" "basic" {
   length = 12
 }`
-
 	testAccResourceStringOverride = `
 resource "random_string" "override" {
 length = 4
@@ -89,7 +105,6 @@ upper = false
 number = false
 }
 `
-
 	testAccResourceStringMin = `
 resource "random_string" "min" {
 length = 12
@@ -98,6 +113,15 @@ min_lower = 2
 min_upper = 3
 min_special = 1
 min_numeric = 4
+}`
+	testAccResourceStringInvalidConfig = `
+resource "random_string" "invalid_length" {
+  length = 2
+  min_lower = 3
+}`
+	testAccResourceStringLengthTooShortConfig = `
+resource "random_string" "invalid_length" {
+  length = 0
 }`
 )
 
@@ -158,15 +182,3 @@ func patternMatch(id string, want string) resource.TestCheckFunc {
 		return nil
 	}
 }
-
-const (
-	testAccResourceStringInvalidConfig = `
-resource "random_string" "invalid_length" {
-  length = 2
-  min_lower = 3
-}`
-	testAccResourceStringLengthTooShortConfig = `
-resource "random_string" "invalid_length" {
-  length = 0
-}`
-)

--- a/internal/provider/resource_uuid_test.go
+++ b/internal/provider/resource_uuid_test.go
@@ -18,7 +18,7 @@ func TestAccResourceUUID(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"random_uuid.basic",
 						"result",
-						regexp.MustCompile("[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}"),
+						regexp.MustCompile(`[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}`),
 					),
 				),
 			},

--- a/internal/provider/resource_uuid_test.go
+++ b/internal/provider/resource_uuid_test.go
@@ -17,16 +17,11 @@ func TestAccResourceUUID(t *testing.T) {
 			{
 				Config: testAccResourceUUIDConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccResourceUUIDCheck("random_uuid.foo"),
+					testAccResourceUUIDCheck("random_uuid.basic"),
 				),
 			},
 			{
-				ResourceName:      "random_uuid.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				ResourceName:      "random_uuid.bar",
+				ResourceName:      "random_uuid.basic",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -57,8 +52,6 @@ func testAccResourceUUIDCheck(id string) resource.TestCheckFunc {
 
 const (
 	testAccResourceUUIDConfig = `
-resource "random_uuid" "foo" { }
-
-resource "random_uuid" "bar" { }
+resource "random_uuid" "basic" { }
 `
 )

--- a/internal/provider/resource_uuid_test.go
+++ b/internal/provider/resource_uuid_test.go
@@ -1,12 +1,10 @@
 package provider
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceUUID(t *testing.T) {
@@ -17,7 +15,11 @@ func TestAccResourceUUID(t *testing.T) {
 			{
 				Config: testAccResourceUUIDConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccResourceUUIDCheck("random_uuid.basic"),
+					resource.TestMatchResourceAttr(
+						"random_uuid.basic",
+						"result",
+						regexp.MustCompile("[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}"),
+					),
 				),
 			},
 			{
@@ -27,27 +29,6 @@ func TestAccResourceUUID(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceUUIDCheck(id string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[id]
-		if !ok {
-			return fmt.Errorf("Not found: %s", id)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		result := rs.Primary.Attributes["result"]
-		matched, err := regexp.MatchString(
-			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", result)
-		if !matched || err != nil {
-			return fmt.Errorf("result string format incorrect, is %s", result)
-		}
-
-		return nil
-	}
 }
 
 const (


### PR DESCRIPTION
### Objectives
- Remove obsolete references to `b64` in `resource_id_test` as `b64` was [deprecated and removed since v3.0.0](https://github.com/hashicorp/terraform-provider-random/issues/10).
- Add explanatory comments to `resource_password_test` to clarify why `Import` had to be run in a separate test.
- Separate `resources` into separate configs.