### PR TITLE
Add a hash to random_password with StateUpgrader

### DIFF
--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -1,22 +1,92 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func resourcePassword() *schema.Resource {
+	passwordSchema := stringSchemaV1(true)
+	passwordSchema["bcrypt_hash"] = &schema.Schema{
+		Type:      schema.TypeString,
+		Computed:  true,
+		Sensitive: true,
+	}
+
+	create := func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		diags := createStringFunc(true)(ctx, d, meta)
+		if diags.HasError() {
+			return diags
+		}
+
+		if d.Get("bcrypt_hash") == "" {
+			hash, err := generateHash(d.Get("result").(string))
+			if err != nil {
+				diags = append(diags, diag.Errorf("err: %s", err)...)
+				return diags
+			}
+
+			if err := d.Set("bcrypt_hash", hash); err != nil {
+				diags = append(diags, diag.Errorf("err: %s", err)...)
+				return diags
+			}
+		}
+
+		return nil
+	}
+
 	return &schema.Resource{
 		Description: "Identical to [random_string](string.html) with the exception that the result is " +
 			"treated as sensitive and, thus, _not_ displayed in console output. Read more about sensitive " +
 			"data handling in the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html).\n" +
 			"\n" +
 			"This resource *does* use a cryptographic random number generator.",
-		CreateContext: createStringFunc(true),
+		CreateContext: create,
 		ReadContext:   readNil,
 		DeleteContext: RemoveResourceFromState,
-		Schema:        stringSchemaV1(true),
+		Schema:        passwordSchema,
 		Importer: &schema.ResourceImporter{
 			StateContext: importStringFunc(true),
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourcePasswordV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourcePasswordStateUpgradeV0,
+			},
+		},
 	}
+}
+
+func resourcePasswordV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: stringSchemaV1(true),
+	}
+}
+
+func resourcePasswordStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	result, ok := rawState["result"].(string)
+	if !ok {
+		return nil, fmt.Errorf("resource password state upgrade failed, result could not be asserted as string: %T", rawState["result"])
+	}
+
+	hash, err := generateHash(result)
+	if err != nil {
+		return nil, fmt.Errorf("resource password state upgrade failed, generate hash error: %v", err)
+	}
+
+	rawState["bcrypt_hash"] = hash
+
+	return rawState, nil
+}
+
+func generateHash(toHash string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(toHash), bcrypt.DefaultCost)
+
+	return string(hash), err
 }

--- a/internal/provider/resource_pasword_test.go
+++ b/internal/provider/resource_pasword_test.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -15,7 +17,9 @@ func TestAccResourcePasswordBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePasswordBasic,
+				Config: `resource "random_password" "basic" {
+							length = 12
+						}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceStringCheck("random_password.basic", &customLens{
 						customLen: 12,
@@ -41,7 +45,7 @@ func TestAccResourcePasswordBasic(t *testing.T) {
 				},
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"length", "lower", "number", "special", "upper", "min_lower", "min_numeric", "min_special", "min_upper", "override_special"},
+				ImportStateVerifyIgnore: []string{"bcrypt_hash", "length", "lower", "number", "special", "upper", "min_lower", "min_numeric", "min_special", "min_upper", "override_special"},
 			},
 		},
 	})
@@ -53,7 +57,13 @@ func TestAccResourcePasswordOverride(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePasswordOverride,
+				Config: `resource "random_password" "override" {
+							length = 4
+							override_special = "!"
+							lower = false
+							upper = false
+							number = false
+						}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceStringCheck("random_password.override", &customLens{
 						customLen: 4,
@@ -71,7 +81,14 @@ func TestAccResourcePasswordMin(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourcePasswordMin,
+				Config: `resource "random_password" "min" {
+							length = 12
+							override_special = "!#@"
+							min_lower = 2
+							min_upper = 3
+							min_special = 1
+							min_numeric = 4
+						}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceStringCheck("random_password.min", &customLens{
 						customLen: 12,
@@ -86,29 +103,51 @@ func TestAccResourcePasswordMin(t *testing.T) {
 	})
 }
 
-const (
-	testAccResourcePasswordBasic = `
-resource "random_password" "basic" {
-  length = 12
-}`
+func TestResourcePasswordStateUpgradeV0(t *testing.T) {
+	cases := []struct {
+		name            string
+		stateV0         map[string]interface{}
+		shouldError     bool
+		errMsg          string
+		expectedStateV1 map[string]interface{}
+	}{
+		{
+			name:        "result is not string",
+			stateV0:     map[string]interface{}{"result": 0},
+			shouldError: true,
+			errMsg:      "resource password state upgrade failed, result could not be asserted as string: int",
+		},
+		{
+			name:            "success",
+			stateV0:         map[string]interface{}{"result": "abc123"},
+			shouldError:     false,
+			expectedStateV1: map[string]interface{}{"result": "abc123", "bcrypt_hash": "123"},
+		},
+	}
 
-	testAccResourcePasswordOverride = `
-resource "random_password" "override" {
-length = 4
-override_special = "!"
-lower = false
-upper = false
-number = false
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actualStateV1, err := resourcePasswordStateUpgradeV0(context.Background(), c.stateV0, nil)
+
+			if c.shouldError {
+				if !cmp.Equal(c.errMsg, err.Error()) {
+					t.Errorf("expected: %q, got: %q", c.errMsg, err)
+				}
+				if !cmp.Equal(c.expectedStateV1, actualStateV1) {
+					t.Errorf("expected: %+v, got: %+v", c.expectedStateV1, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("err should be nil, actual: %v", err)
+				}
+
+				for k := range c.expectedStateV1 {
+					_, ok := actualStateV1[k]
+					if !ok {
+						t.Errorf("expected key: %s is missing from state", k)
+					}
+				}
+			}
+		})
+	}
 }
-`
-
-	testAccResourcePasswordMin = `
-resource "random_password" "min" {
-length = 12
-override_special = "!#@"
-min_lower = 2
-min_upper = 3
-min_special = 1
-min_numeric = 4
-}`
-)

--- a/internal/provider/string.go
+++ b/internal/provider/string.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"math/big"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func stringSchemaV1(sensitive bool) map[string]*schema.Schema {


### PR DESCRIPTION
This is evaluating whether the changes proposed in https://github.com/hashicorp/terraform-provider-random/pull/73 can be combined with a StateUpgrader to avoid the situation where including the `bcrypt_hash` field generates an empty value in state on first use.