### PR TITLE
Only assign value of number to numeric if number is bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 BUG FIXES:
 
-* resource/random_password: Only assign value of number to numeric when value is boolean ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
-* resource/random_string: Only assign value of number to numeric when value is boolean ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
+* resource/random_password: During schema upgrade, copy value of attribute `number` to attribute `numeric`, only if said value is a boolean (i.e. not `null`) ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
+* resource/random_string: During schema upgrade, copy value of attribute `number` to attribute `numeric`, only if said value is a boolean (i.e. not `null`) ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
 
 ## 3.3.0 (June 06, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 3.3.0 (Unreleased)
+## 3.3.1 (June 07, 2022)
+
+BUG FIXES:
+
+* resource/random_password: Only assign value of number to numeric when value is boolean ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
+* resource/random_string: Only assign value of number to numeric when value is boolean ([262](https://github.com/hashicorp/terraform-provider-random/pull/262))
+
+## 3.3.0 (June 06, 2022)
 
 ENHANCEMENTS:
 

--- a/internal/provider/string.go
+++ b/internal/provider/string.go
@@ -329,12 +329,9 @@ func resourcePasswordStringStateUpgradeV1(_ context.Context, rawState map[string
 		return nil, errors.New("state upgrade failed, state is nil")
 	}
 
-	number, ok := rawState["number"].(bool)
-	if !ok {
-		return nil, fmt.Errorf("state upgrade failed, number is not a boolean: %T", rawState["number"])
+	if number, ok := rawState["number"].(bool); ok {
+		rawState["numeric"] = number
 	}
-
-	rawState["numeric"] = number
 
 	return rawState, nil
 }

--- a/internal/provider/string_test.go
+++ b/internal/provider/string_test.go
@@ -21,9 +21,9 @@ func TestResourcePasswordStringStateUpgradeV1(t *testing.T) {
 			err:     errors.New("state upgrade failed, state is nil"),
 		},
 		{
-			name:    "number is not bool",
-			stateV1: map[string]interface{}{"number": 0},
-			err:     errors.New("state upgrade failed, number is not a boolean: int"),
+			name:            "number is not bool, raw state unaltered",
+			stateV1:         map[string]interface{}{"number": 0},
+			expectedStateV2: map[string]interface{}{"number": 0},
 		},
 		{
 			name:            "success",


### PR DESCRIPTION
A bug report (https://github.com/hashicorp/terraform-provider-random/issues/261) indicates that following upgrading to `v3.3.0` running `terraform plan` results in the following error:
```bash
│ Error: state upgrade failed, number is not a boolean: <nil>
│ 
│   with random_password.test,
│   on temp-resources.tf line 1, in resource "random_password" "test":
│    1: resource "random_password" "test" {
│ 
```

Attempts to replicate this bug were unsuccessful using the [approaches described](https://github.com/hashicorp/terraform-provider-random/issues/261#issuecomment-1147935812).

The only way I could find to replicate this bug was to run `terraform import random_password.test <password>` using `v3.2.0` and then to upgrade to `v3.3.0` and run `terraform plan`. 

The [reported bug](https://github.com/hashicorp/terraform-provider-random/issues/261) appears to arise because `number` is `null` within `.tfstate`. The issue with null values being present in the `.tfstate` file following import and the fact that this forces a replacement has been described in pull requests (e.g., https://github.com/hashicorp/terraform-provider-random/pull/256) and issues (e.g., https://github.com/hashicorp/terraform-provider-random/issues/119, https://github.com/hashicorp/terraform-provider-random/issues/106) previously. 

This PR _does not_ address the issue of null values being present in `.tfstate` following import of either `random_password` or `random_string` but tackles restoring the "known" behaviour of `terraform plan` or `terraform apply` forcing replacement following import.