### PR TITLE
Switching to protocol version 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
           - windows-latest
           - ubuntu-latest
         terraform:
+          - '0.12.*'
+          - '0.13.*'
+          - '0.14.*'
+          - '0.15.*'
           - '1.0.*'
           - '1.1.*'
           - '1.2.*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-## 4.0.0-rc.1 (unreleased)
+## 4.0.0 (unreleased)
 
 NOTES:
 
 * Provider has been re-written using the new [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework) ([#177](https://github.com/hashicorp/terraform-provider-random/pull/177)).
 
 BREAKING CHANGES:
-
-* [Terraform `>=1.0`](https://www.terraform.io/language/upgrade-guides/1-0) is now required to use this provider.
 
 * resource/random_password: Deprecated attribute `number` has been removed ([266](https://github.com/hashicorp/terraform-provider-random/issues/266)).
 * resource/random_string: Deprecated attribute `number` has been removed ([266](https://github.com/hashicorp/terraform-provider-random/issues/266)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 NOTES:
 
 * Provider has been re-written using the new [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework) ([#177](https://github.com/hashicorp/terraform-provider-random/pull/177)).
+* resource/random_password: `number` was deprecated in [v3.3.0](https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.3.0) and will be removed in the next major release.
+* resource/random_string: `number` was deprecated in [v3.3.0](https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.3.0) and will be removed in the next major release.
 
 ## 3.3.2 (June 23, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,8 @@
-## 4.0.0 (unreleased)
+## 3.4.0 (unreleased)
 
 NOTES:
 
 * Provider has been re-written using the new [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework) ([#177](https://github.com/hashicorp/terraform-provider-random/pull/177)).
-
-BREAKING CHANGES:
-
-* resource/random_password: Deprecated attribute `number` has been removed ([266](https://github.com/hashicorp/terraform-provider-random/issues/266)).
-* resource/random_string: Deprecated attribute `number` has been removed ([266](https://github.com/hashicorp/terraform-provider-random/issues/266)).
 
 ## 3.3.2 (June 23, 2022)
 

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -45,6 +45,7 @@ resource "aws_db_instance" "example" {
 - `min_numeric` (Number) Minimum number of numeric characters in the result. Default value is `0`.
 - `min_special` (Number) Minimum number of special characters in the result. Default value is `0`.
 - `min_upper` (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
+- `number` (Boolean, Deprecated) Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.
 - `numeric` (Boolean) Include numeric characters in the result. Default value is `true`.
 - `override_special` (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
 - `special` (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.

--- a/docs/resources/string.md
+++ b/docs/resources/string.md
@@ -40,6 +40,7 @@ resource "random_string" "random" {
 - `min_numeric` (Number) Minimum number of numeric characters in the result. Default value is `0`.
 - `min_special` (Number) Minimum number of special characters in the result. Default value is `0`.
 - `min_upper` (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
+- `number` (Boolean, Deprecated) Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.
 - `numeric` (Boolean) Include numeric characters in the result. Default value is `true`.
 - `override_special` (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
 - `special` (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.

--- a/internal/planmodifiers/attribute.go
+++ b/internal/planmodifiers/attribute.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // DefaultValue accepts an attr.Value and uses the supplied value to set a default if the config for
@@ -83,4 +85,75 @@ func (r RequiresReplaceModifier) Modify(ctx context.Context, req tfsdk.ModifyAtt
 	}
 
 	resp.RequiresReplace = true
+}
+
+func NumberNumericAttributePlanModifier() tfsdk.AttributePlanModifier {
+	return &numberNumericAttributePlanModifier{}
+}
+
+type numberNumericAttributePlanModifier struct {
+}
+
+func (d *numberNumericAttributePlanModifier) Description(ctx context.Context) string {
+	return ""
+}
+
+func (d *numberNumericAttributePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return ""
+}
+
+func (d *numberNumericAttributePlanModifier) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+	numberConfig := types.Bool{}
+	diags := req.Config.GetAttribute(ctx, path.Root("number"), &numberConfig)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	numericConfig := types.Bool{}
+	req.Config.GetAttribute(ctx, path.Root("numeric"), &numericConfig)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !numberConfig.Null && !numericConfig.Null {
+		resp.Diagnostics.AddError(
+			"Number numeric attribute plan modifier failed",
+			"Cannot specify both number and numeric in config",
+		)
+		return
+	}
+
+	numberPlan := types.Bool{}
+	diags = req.Config.GetAttribute(ctx, path.Root("number"), &numberPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	numericPlan := types.Bool{}
+	req.Config.GetAttribute(ctx, path.Root("numeric"), &numericPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Default to true for both number and numeric when both are null.
+	if numberPlan.Null && numericPlan.Null {
+		resp.AttributePlan = types.Bool{Value: true}
+		return
+	}
+
+	// Default to using value for numeric if number is null
+	if numberPlan.Null && !numericPlan.Null {
+		resp.AttributePlan = numericPlan
+		return
+	}
+
+	// Default to using value for number if numeric is null
+	if !numberPlan.Null && numericPlan.Null {
+		resp.AttributePlan = numberPlan
+		return
+	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -15,7 +15,7 @@ func protoV5ProviderFactories() map[string]func() (tfprotov5.ProviderServer, err
 
 func providerVersion332() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
-		"tls": {
+		"random": {
 			VersionConstraint: "3.3.2",
 			Source:            "hashicorp/random",
 		},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,14 +2,14 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 //nolint:unparam
-func protoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
-	return map[string]func() (tfprotov6.ProviderServer, error){
-		"random": providerserver.NewProtocol6WithError(New()),
+func protoV5ProviderFactories() map[string]func() (tfprotov5.ProviderServer, error) {
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		"random": providerserver.NewProtocol5WithError(New()),
 	}
 }
 

--- a/internal/provider/resource_id_test.go
+++ b/internal/provider/resource_id_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAccResourceID(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_id" "foo" {
@@ -32,7 +32,7 @@ func TestAccResourceID(t *testing.T) {
 
 func TestAccResourceID_ImportWithPrefix(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_id" "bar" {
@@ -73,7 +73,7 @@ func TestAccResourceID_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_id" "bar" {
   							byte_length = 4
   							prefix      = "cloud-"
@@ -81,7 +81,7 @@ func TestAccResourceID_UpgradeFromVersion3_3_2(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_id" "bar" {
   							byte_length = 4
   							prefix      = "cloud-"

--- a/internal/provider/resource_integer_test.go
+++ b/internal/provider/resource_integer_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccResourceInteger(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_integer" "integer_1" {
@@ -35,7 +35,7 @@ func TestAccResourceInteger(t *testing.T) {
 func TestAccResourceInteger_ChangeSeed(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_integer" "integer_1" {
@@ -64,7 +64,7 @@ func TestAccResourceInteger_ChangeSeed(t *testing.T) {
 func TestAccResourceInteger_SeedlessToSeeded(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_integer" "integer_1" {
@@ -92,7 +92,7 @@ func TestAccResourceInteger_SeedlessToSeeded(t *testing.T) {
 func TestAccResourceInteger_SeededToSeedless(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_integer" "integer_1" {
@@ -120,7 +120,7 @@ func TestAccResourceInteger_SeededToSeedless(t *testing.T) {
 func TestAccResourceInteger_Big(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_integer" "integer_1" {
@@ -154,7 +154,7 @@ func TestAccResourceInteger_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_integer" "integer_1" {
    							min  = 1
 							max  = 3
@@ -163,7 +163,7 @@ func TestAccResourceInteger_UpgradeFromVersion3_3_2(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_integer" "integer_1" {
    							min  = 1
 							max  = 3

--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -70,6 +70,7 @@ func (r *passwordResource) Create(ctx context.Context, req tfsdk.CreateResourceR
 		Special:         types.Bool{Value: plan.Special.Value},
 		Upper:           types.Bool{Value: plan.Upper.Value},
 		Lower:           types.Bool{Value: plan.Lower.Value},
+		Number:          types.Bool{Value: plan.Number.Value},
 		Numeric:         types.Bool{Value: plan.Numeric.Value},
 		MinNumeric:      types.Int64{Value: plan.MinNumeric.Value},
 		MinUpper:        types.Int64{Value: plan.MinUpper.Value},
@@ -117,6 +118,7 @@ func (r *passwordResource) ImportState(ctx context.Context, req tfsdk.ImportReso
 		Special:    types.Bool{Value: true},
 		Upper:      types.Bool{Value: true},
 		Lower:      types.Bool{Value: true},
+		Number:     types.Bool{Value: true},
 		Numeric:    types.Bool{Value: true},
 		MinSpecial: types.Int64{Value: 0},
 		MinUpper:   types.Int64{Value: 0},
@@ -186,6 +188,7 @@ func upgradePasswordStateV0toV2(ctx context.Context, req tfsdk.UpgradeResourceSt
 		Special:         passwordDataV0.Special,
 		Upper:           passwordDataV0.Upper,
 		Lower:           passwordDataV0.Lower,
+		Number:          passwordDataV0.Number,
 		Numeric:         passwordDataV0.Number,
 		MinNumeric:      passwordDataV0.MinNumeric,
 		MinLower:        passwordDataV0.MinLower,
@@ -238,6 +241,7 @@ func upgradePasswordStateV1toV2(ctx context.Context, req tfsdk.UpgradeResourceSt
 		Special:         passwordDataV1.Special,
 		Upper:           passwordDataV1.Upper,
 		Lower:           passwordDataV1.Lower,
+		Number:          passwordDataV1.Number,
 		Numeric:         passwordDataV1.Number,
 		MinNumeric:      passwordDataV1.MinNumeric,
 		MinLower:        passwordDataV1.MinLower,
@@ -331,13 +335,26 @@ func passwordSchemaV2() tfsdk.Schema {
 				},
 			},
 
+			"number": {
+				Description: "Include numeric characters in the result. Default value is `true`. " +
+					"**NOTE**: This is deprecated, use `numeric` instead.",
+				Type:     types.BoolType,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+				DeprecationMessage: "**NOTE**: This is deprecated, use `numeric` instead.",
+			},
+
 			"numeric": {
 				Description: "Include numeric characters in the result. Default value is `true`.",
 				Type:        types.BoolType,
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
-					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.NumberNumericAttributePlanModifier(),
 					planmodifiers.RequiresReplace(),
 				},
 			},
@@ -740,6 +757,7 @@ type passwordModelV2 struct {
 	Special         types.Bool   `tfsdk:"special"`
 	Upper           types.Bool   `tfsdk:"upper"`
 	Lower           types.Bool   `tfsdk:"lower"`
+	Number          types.Bool   `tfsdk:"number"`
 	Numeric         types.Bool   `tfsdk:"numeric"`
 	MinNumeric      types.Int64  `tfsdk:"min_numeric"`
 	MinUpper        types.Int64  `tfsdk:"min_upper"`

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccResourcePassword(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_password" "basic" {
@@ -54,7 +54,7 @@ func TestAccResourcePassword(t *testing.T) {
 
 func TestAccResourcePassword_Override(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_password" "override" {
@@ -281,7 +281,7 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 						Check:  resource.ComposeTestCheckFunc(c.beforeStateUpgrade...),
 					},
 					{
-						ProtoV6ProviderFactories: protoV6ProviderFactories(),
+						ProtoV5ProviderFactories: protoV5ProviderFactories(),
 						Config:                   c.configDuringUpgrade,
 						Check:                    resource.ComposeTestCheckFunc(c.afterStateUpgrade...),
 					},
@@ -490,7 +490,7 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 						Check:  resource.ComposeTestCheckFunc(c.beforeStateUpgrade...),
 					},
 					{
-						ProtoV6ProviderFactories: protoV6ProviderFactories(),
+						ProtoV5ProviderFactories: protoV5ProviderFactories(),
 						Config:                   c.configDuringUpgrade,
 						Check:                    resource.ComposeTestCheckFunc(c.afterStateUpgrade...),
 					},
@@ -502,7 +502,7 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 
 func TestAccResourcePassword_Min(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_password" "min" {
@@ -556,7 +556,7 @@ func TestAccResourcePassword_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_password" "min" {
 							length = 12
 							override_special = "!#@"
@@ -568,7 +568,7 @@ func TestAccResourcePassword_UpgradeFromVersion3_3_2(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_password" "min" {
 							length = 12
 							override_special = "!#@"

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -74,8 +74,7 @@ func TestAccResourcePassword_Override(t *testing.T) {
 }
 
 // TestAccResourcePassword_StateUpgradeV0toV2 covers the state upgrades from V0 to V2.
-// This includes the deprecation and removal of `number` and the addition of `numeric`
-// and `bcrypt_hash` attributes.
+// This includes the the addition of `numeric` and `bcrypt_hash` attributes.
 // v3.1.3 is used as this is last version before `bcrypt_hash` attributed was added.
 func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 	t.Parallel()
@@ -103,7 +102,7 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 			},
 		},
 		{
-			name: "number is absent before numeric is absent during",
+			name: "number is absent before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_password" "default" {
 						length = 12
 					}`,
@@ -115,8 +114,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -133,9 +132,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
-			},
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric")},
 		},
 		{
 			name: "number is absent before numeric is false during",
@@ -151,12 +149,12 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
-			name: "number is true before numeric is absent during",
+			name: "number is true before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_password" "default" {
 						length = 12
 						number = true
@@ -169,26 +167,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
-			},
-		},
-		{
-			name: "number is true before numeric is absent during",
-			configBeforeUpgrade: `resource "random_password" "default" {
-						length = 12
-						number = true
-					}`,
-			configDuringUpgrade: `resource "random_password" "default" {
-						length = 12
-					}`,
-			beforeStateUpgrade: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
-			},
-			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -206,8 +186,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -225,8 +205,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -243,8 +223,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -262,8 +242,8 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 	}
@@ -292,7 +272,7 @@ func TestAccResourcePassword_StateUpgradeV0toV2(t *testing.T) {
 }
 
 // TestAccResourcePassword_StateUpgrade_V1toV2 covers the state upgrades from V1 to V2.
-// This includes the deprecation and removal of `number` and the addition of `numeric` attributes.
+// This includes the addition of `numeric` attribute.
 // v3.2.0 was used as this is the last version before `number` was deprecated and `numeric` attribute
 // was added.
 func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
@@ -306,7 +286,7 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 		afterStateUpgrade   []resource.TestCheckFunc
 	}{
 		{
-			name: "number is absent before numeric is absent during",
+			name: "number is absent before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_password" "default" {
 						length = 12
 					}`,
@@ -318,8 +298,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -336,8 +316,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -354,8 +334,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -373,12 +353,12 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
-			name: "number is true before numeric is absent during",
+			name: "number is true before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_password" "default" {
 						length = 12
 						number = true
@@ -391,8 +371,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -410,8 +390,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -429,8 +409,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -447,8 +427,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 		{
@@ -466,8 +446,8 @@ func TestAccResourcePassword_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_password.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_password.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_password.default", "number"),
+				resource.TestCheckResourceAttr("random_password.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_password.default", "number", "random_password.default", "numeric"),
 			},
 		},
 	}
@@ -547,6 +527,7 @@ func TestAccResourcePassword_UpgradeFromVersion3_3_2(t *testing.T) {
 					resource.TestCheckResourceAttr("random_password.min", "special", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "upper", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "lower", "true"),
+					resource.TestCheckResourceAttr("random_password.min", "number", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "numeric", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "min_special", "1"),
 					resource.TestCheckResourceAttr("random_password.min", "min_upper", "3"),
@@ -586,6 +567,7 @@ func TestAccResourcePassword_UpgradeFromVersion3_3_2(t *testing.T) {
 					resource.TestCheckResourceAttr("random_password.min", "special", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "upper", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "lower", "true"),
+					resource.TestCheckResourceAttr("random_password.min", "number", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "numeric", "true"),
 					resource.TestCheckResourceAttr("random_password.min", "min_special", "1"),
 					resource.TestCheckResourceAttr("random_password.min", "min_upper", "3"),
@@ -637,6 +619,7 @@ func TestUpgradePasswordStateV0toV2(t *testing.T) {
 		Special:         types.Bool{Value: true},
 		Upper:           types.Bool{Value: true},
 		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
 		Numeric:         types.Bool{Value: true},
 		MinNumeric:      types.Int64{Value: 0},
 		MinUpper:        types.Int64{Value: 0},
@@ -705,6 +688,7 @@ func TestUpgradePasswordStateV1toV2(t *testing.T) {
 		Special:         types.Bool{Value: true},
 		Upper:           types.Bool{Value: true},
 		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
 		Numeric:         types.Bool{Value: true},
 		MinNumeric:      types.Int64{Value: 0},
 		MinUpper:        types.Int64{Value: 0},

--- a/internal/provider/resource_pet_test.go
+++ b/internal/provider/resource_pet_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccResourcePet(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_pet" "pet_1" {
@@ -26,7 +26,7 @@ func TestAccResourcePet(t *testing.T) {
 
 func TestAccResourcePet_Length(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_pet" "pet_1" {
@@ -42,7 +42,7 @@ func TestAccResourcePet_Length(t *testing.T) {
 
 func TestAccResourcePet_Prefix(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_pet" "pet_1" {
@@ -59,7 +59,7 @@ func TestAccResourcePet_Prefix(t *testing.T) {
 
 func TestAccResourcePet_Separator(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_pet" "pet_1" {
@@ -88,14 +88,14 @@ func TestAccResourcePet_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_pet" "pet_1" {
   							prefix = "consul"
 						}`,
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_pet" "pet_1" {
   							prefix = "consul"
 						}`,

--- a/internal/provider/resource_shuffle_test.go
+++ b/internal/provider/resource_shuffle_test.go
@@ -18,7 +18,7 @@ import (
 // guaranteed consistent across Terraform releases.
 func TestAccResourceShuffle(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_shuffle" "default_length" {
@@ -40,7 +40,7 @@ func TestAccResourceShuffle(t *testing.T) {
 
 func TestAccResourceShuffle_Shorter(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_shuffle" "shorter_length" {
@@ -61,7 +61,7 @@ func TestAccResourceShuffle_Shorter(t *testing.T) {
 
 func TestAccResourceShuffle_Longer(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_shuffle" "longer_length" {
@@ -91,7 +91,7 @@ func TestAccResourceShuffle_Longer(t *testing.T) {
 
 func TestAccResourceShuffle_Empty(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_shuffle" "empty_length" {
@@ -109,7 +109,7 @@ func TestAccResourceShuffle_Empty(t *testing.T) {
 
 func TestAccResourceShuffle_One(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_shuffle" "one_length" {
@@ -145,7 +145,7 @@ func TestAccResourceShuffle_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_shuffle" "default_length" {
     						input = ["a", "b", "c", "d", "e"]
     						seed = "-"
@@ -153,7 +153,7 @@ func TestAccResourceShuffle_UpgradeFromVersion3_3_2(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_shuffle" "default_length" {
     						input = ["a", "b", "c", "d", "e"]
     						seed = "-"

--- a/internal/provider/resource_string.go
+++ b/internal/provider/resource_string.go
@@ -92,13 +92,26 @@ func (r stringResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagn
 				},
 			},
 
+			"number": {
+				Description: "Include numeric characters in the result. Default value is `true`. " +
+					"**NOTE**: This is deprecated, use `numeric` instead.",
+				Type:     types.BoolType,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+				DeprecationMessage: "**NOTE**: This is deprecated, use `numeric` instead.",
+			},
+
 			"numeric": {
 				Description: "Include numeric characters in the result. Default value is `true`.",
 				Type:        types.BoolType,
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
-					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.NumberNumericAttributePlanModifier(),
 					planmodifiers.RequiresReplace(),
 				},
 			},
@@ -221,6 +234,7 @@ func (r *stringResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 		Special:         types.Bool{Value: plan.Special.Value},
 		Upper:           types.Bool{Value: plan.Upper.Value},
 		Lower:           types.Bool{Value: plan.Lower.Value},
+		Number:          types.Bool{Value: plan.Number.Value},
 		Numeric:         types.Bool{Value: plan.Numeric.Value},
 		MinNumeric:      types.Int64{Value: plan.MinNumeric.Value},
 		MinUpper:        types.Int64{Value: plan.MinUpper.Value},
@@ -261,6 +275,7 @@ func (r *stringResource) ImportState(ctx context.Context, req tfsdk.ImportResour
 		Special:    types.Bool{Value: true},
 		Upper:      types.Bool{Value: true},
 		Lower:      types.Bool{Value: true},
+		Number:     types.Bool{Value: true},
 		Numeric:    types.Bool{Value: true},
 		MinSpecial: types.Int64{Value: 0},
 		MinUpper:   types.Int64{Value: 0},
@@ -470,6 +485,7 @@ func upgradeStringStateV1toV2(ctx context.Context, req tfsdk.UpgradeResourceStat
 		Special:         stringDataV1.Special,
 		Upper:           stringDataV1.Upper,
 		Lower:           stringDataV1.Lower,
+		Number:          stringDataV1.Number,
 		Numeric:         stringDataV1.Number,
 		MinNumeric:      stringDataV1.MinNumeric,
 		MinLower:        stringDataV1.MinLower,
@@ -490,6 +506,7 @@ type stringModelV2 struct {
 	Special         types.Bool   `tfsdk:"special"`
 	Upper           types.Bool   `tfsdk:"upper"`
 	Lower           types.Bool   `tfsdk:"lower"`
+	Number          types.Bool   `tfsdk:"number"`
 	Numeric         types.Bool   `tfsdk:"numeric"`
 	MinNumeric      types.Int64  `tfsdk:"min_numeric"`
 	MinUpper        types.Int64  `tfsdk:"min_upper"`

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccResourceString(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_string" "basic" {
@@ -31,7 +31,7 @@ func TestAccResourceString(t *testing.T) {
 
 func TestAccResourceString_Override(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_string" "override" {
@@ -52,7 +52,7 @@ func TestAccResourceString_Override(t *testing.T) {
 
 func TestAccResourceString_Min(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_string" "min" {
@@ -269,7 +269,7 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 						Check:  resource.ComposeTestCheckFunc(c.beforeStateUpgrade...),
 					},
 					{
-						ProtoV6ProviderFactories: protoV6ProviderFactories(),
+						ProtoV5ProviderFactories: protoV5ProviderFactories(),
 						Config:                   c.configDuringUpgrade,
 						Check:                    resource.ComposeTestCheckFunc(c.afterStateUpgrade...),
 					},
@@ -281,7 +281,7 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 
 func TestAccResourceString_LengthErrors(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_string" "invalid_length" {
@@ -330,7 +330,7 @@ func TestAccResourceString_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_string" "min" {
 							length = 12
 							override_special = "!#@"
@@ -342,7 +342,7 @@ func TestAccResourceString_UpgradeFromVersion3_3_2(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_string" "min" {
 							length = 12
 							override_special = "!#@"

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -76,7 +76,7 @@ func TestAccResourceString_Min(t *testing.T) {
 }
 
 // TestAccResourceString_StateUpgradeV1toV2 covers the state upgrade from V1 to V2.
-// This includes the deprecation and removal of `number` and the addition of `numeric` attributes.
+// This includes the deprecation of `number` and the addition of `numeric` attributes.
 // v3.2.0 was used as this is the last version before `number` was deprecated and `numeric` attribute
 // was added.
 func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
@@ -90,7 +90,7 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 		afterStateUpgrade   []resource.TestCheckFunc
 	}{
 		{
-			name: "number is absent before numeric is absent during",
+			name: "number is absent before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_string" "default" {
 						length = 12
 					}`,
@@ -102,8 +102,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -120,8 +120,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -138,8 +138,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -157,12 +157,12 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
-			name: "number is true before numeric is absent during",
+			name: "number is true before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_string" "default" {
 						length = 12
 						number = true
@@ -175,8 +175,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -194,8 +194,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -213,12 +213,12 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "false"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "false"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
-			name: "number is false before numeric is absent during",
+			name: "number is false before number and numeric are absent during",
 			configBeforeUpgrade: `resource "random_string" "default" {
 						length = 12
 						number = false
@@ -231,8 +231,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 		{
@@ -250,8 +250,8 @@ func TestAccResourceString_StateUpgradeV1toV2(t *testing.T) {
 				resource.TestCheckNoResourceAttr("random_string.default", "numeric"),
 			},
 			afterStateUpgrade: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("random_string.default", "numeric", "true"),
-				resource.TestCheckNoResourceAttr("random_string.default", "number"),
+				resource.TestCheckResourceAttr("random_string.default", "number", "true"),
+				resource.TestCheckResourceAttrPair("random_string.default", "number", "random_string.default", "numeric"),
 			},
 		},
 	}
@@ -322,6 +322,7 @@ func TestAccResourceString_UpgradeFromVersion3_3_2(t *testing.T) {
 					resource.TestCheckResourceAttr("random_string.min", "special", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "upper", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "lower", "true"),
+					resource.TestCheckResourceAttr("random_string.min", "number", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "numeric", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "min_special", "1"),
 					resource.TestCheckResourceAttr("random_string.min", "min_upper", "3"),
@@ -360,6 +361,7 @@ func TestAccResourceString_UpgradeFromVersion3_3_2(t *testing.T) {
 					resource.TestCheckResourceAttr("random_string.min", "special", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "upper", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "lower", "true"),
+					resource.TestCheckResourceAttr("random_string.min", "number", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "numeric", "true"),
 					resource.TestCheckResourceAttr("random_string.min", "min_special", "1"),
 					resource.TestCheckResourceAttr("random_string.min", "min_upper", "3"),

--- a/internal/provider/resource_uuid_test.go
+++ b/internal/provider/resource_uuid_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccResourceUUID(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_uuid" "basic" { 
@@ -39,13 +39,13 @@ func TestAccResourceUUID_UpgradeFromVersion3_3_2(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_uuid" "basic" { 
 						}`,
 				PlanOnly: true,
 			},
 			{
-				ProtoV6ProviderFactories: protoV6ProviderFactories(),
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
 				Config: `resource "random_uuid" "basic" { 
 						}`,
 				Check: resource.ComposeTestCheckFunc(

--- a/main.go
+++ b/main.go
@@ -27,8 +27,9 @@ func main() {
 	flag.Parse()
 
 	err := providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
-		Address: "registry.terraform.io/hashicorp/random",
-		Debug:   debug,
+		Address:         "registry.terraform.io/hashicorp/random",
+		Debug:           debug,
+		ProtocolVersion: 5,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
     "metadata": {
-        "protocol_versions": ["6.0"]
+        "protocol_versions": ["5.0"]
     }
 }


### PR DESCRIPTION
This PR sets the protocol version used by the provider to `5` to preserve backwards compatibility with Terraform >= `v0.12.x`