### PR TITLE
resource/random_password: Fix bcrypt_hash generation

### DIFF
--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -82,7 +82,7 @@ func (r *passwordResource) Create(ctx context.Context, req resource.CreateReques
 		Result:          types.String{Value: string(result)},
 	}
 
-	hash, err := generateHash(plan.Result.Value)
+	hash, err := generateHash(string(result))
 	if err != nil {
 		resp.Diagnostics.Append(diagnostics.HashGenerationError(err.Error())...)
 	}


### PR DESCRIPTION
Closes #307

This change fixes the source of the `bcrypt_hash` generation to being the result of the random password generation. The issue was introduced in v3.4.0.

Previously:

```
--- FAIL: TestAccResourcePassword_BcryptHash (0.63s)
    /Users/bflad/src/github.com/hashicorp/terraform-provider-random/internal/provider/resource_password_test.go:107: Step 1/1 error: Check failed: Check 3/3 error: crypto/bcrypt: hashedPassword is not the hash of the given password
```

Suggested CHANGELOG:

```
NOTES:

* resource/random_password: If the resource was created between versions 3.4.0 and 3.4.2, the `bcrypt_hash` value will not correctly verify against the `result` value. Use `terraform taint` or `terraform apply -replace` to trigger resource recreation with this version.

BUG FIXES:

* resource/random_password: Fixed incorrect `bcrypt_hash` generation since version 3.4.0
```