### PR TITLE
make referencing path to example generic

### DIFF
--- a/templates/resources/password.md.tmpl
+++ b/templates/resources/password.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ## Example Usage
 
-{{ tffile "examples/resources/random_password/resource.tf" }}
+{{ tffile (printf "examples/resources/%s/resource.tf" .Name)}}
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates/resources/string.md.tmpl
+++ b/templates/resources/string.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ## Example Usage
 
-{{ tffile "examples/resources/random_string/resource.tf" }}
+{{ tffile (printf "examples/resources/%s/resource.tf" .Name)}}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
since terraform provider random is mentioned as inspiring example for [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs) the reference to the examples in the documentation templates is coded generic to avoid "copy-paste-forget-to-edit" failures 