### PR TITLE
Fix null values in state forcing replace

### DIFF
--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -350,7 +350,7 @@ func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRe
 		numeric.Value = true
 	}
 
-	passwordDataV3 := passwordModelV2{
+	passwordDataV3 := passwordModelV3{
 		Keepers:         passwordDataV2.Keepers,
 		Length:          passwordDataV2.Length,
 		Special:         special,


### PR DESCRIPTION
There are several comments on [Upgrade v2.2.1 -> v3.4.0 forces replacement](https://github.com/hashicorp/terraform-provider-random/issues/302#top) which indicate that a forced recreate occurs when there are null values in the state for certain attributes:

- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1233159123
- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1233263617
- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1235721338

The attributes in question appear to be:
```
"lower": null
"min_lower": null
"min_numeric": null
"min_special": null
"min_upper": null
"number": null
"numeric": null
"special": null
"upper": null
```

This PR attempts to address this issue by using a state upgrader to set each of these attributes to be non-null and to have the appropriate default value (e.g., `0` for `lower`, `true` for `min_lower`).