### PR TITLE
Implement State Upgrader to Set Defaults for Attributes Assigned Null During Import

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -22,6 +22,15 @@ func providerVersion221() map[string]resource.ExternalProvider {
 	}
 }
 
+func providerVersion313() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"random": {
+			VersionConstraint: "3.1.3",
+			Source:            "hashicorp/random",
+		},
+	}
+}
+
 func providerVersion320() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"random": {

--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -23,7 +23,7 @@ var _ provider.ResourceType = (*passwordResourceType)(nil)
 type passwordResourceType struct{}
 
 func (r *passwordResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
-	return passwordSchemaV3(), nil
+	return passwordSchemaV4(), nil
 }
 
 func (r *passwordResourceType) NewResource(_ context.Context, _ provider.Provider) (resource.Resource, diag.Diagnostics) {
@@ -39,7 +39,7 @@ var (
 type passwordResource struct{}
 
 func (r *passwordResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan passwordModelV3
+	var plan passwordModelV4
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -84,7 +84,7 @@ func (r *passwordResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update ensures the plan value is copied to the state to complete the update.
 func (r *passwordResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model passwordModelV3
+	var model passwordModelV4
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
 
@@ -103,7 +103,7 @@ func (r *passwordResource) Delete(ctx context.Context, req resource.DeleteReques
 func (r *passwordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := req.ID
 
-	state := passwordModelV3{
+	state := passwordModelV4{
 		ID:         types.String{Value: "none"},
 		Result:     types.String{Value: id},
 		Length:     types.Int64{Value: int64(len(id))},
@@ -141,24 +141,29 @@ func (r *passwordResource) UpgradeState(context.Context) map[int64]resource.Stat
 	schemaV0 := passwordSchemaV0()
 	schemaV1 := passwordSchemaV1()
 	schemaV2 := passwordSchemaV2()
+	schemaV3 := passwordSchemaV3()
 
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema:   &schemaV0,
-			StateUpgrader: upgradePasswordStateV0toV3,
+			StateUpgrader: upgradePasswordStateV0toV4,
 		},
 		1: {
 			PriorSchema:   &schemaV1,
-			StateUpgrader: upgradePasswordStateV1toV3,
+			StateUpgrader: upgradePasswordStateV1toV4,
 		},
 		2: {
 			PriorSchema:   &schemaV2,
-			StateUpgrader: upgradePasswordStateV2toV3,
+			StateUpgrader: upgradePasswordStateV2toV4,
+		},
+		3: {
+			PriorSchema:   &schemaV3,
+			StateUpgrader: upgradePasswordStateV3toV4,
 		},
 	}
 }
 
-func upgradePasswordStateV0toV3(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+func upgradePasswordStateV0toV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	type modelV0 struct {
 		ID              types.String `tfsdk:"id"`
 		Keepers         types.Map    `tfsdk:"keepers"`
@@ -182,36 +187,99 @@ func upgradePasswordStateV0toV3(ctx context.Context, req resource.UpgradeStateRe
 		return
 	}
 
-	passwordDataV3 := passwordModelV3{
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := passwordDataV0.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(passwordDataV0.Result.Value))
+	}
+
+	minNumeric := passwordDataV0.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := passwordDataV0.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := passwordDataV0.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := passwordDataV0.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := passwordDataV0.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := passwordDataV0.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := passwordDataV0.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := passwordDataV0.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	passwordDataV4 := passwordModelV4{
 		Keepers:         passwordDataV0.Keepers,
-		Length:          passwordDataV0.Length,
-		Special:         passwordDataV0.Special,
-		Upper:           passwordDataV0.Upper,
-		Lower:           passwordDataV0.Lower,
-		Number:          passwordDataV0.Number,
-		Numeric:         passwordDataV0.Number,
-		MinNumeric:      passwordDataV0.MinNumeric,
-		MinUpper:        passwordDataV0.MinUpper,
-		MinLower:        passwordDataV0.MinLower,
-		MinSpecial:      passwordDataV0.MinSpecial,
+		Length:          length,
+		Special:         special,
+		Upper:           upper,
+		Lower:           lower,
+		Number:          number,
+		Numeric:         number,
+		MinNumeric:      minNumeric,
+		MinUpper:        minUpper,
+		MinLower:        minLower,
+		MinSpecial:      minSpecial,
 		OverrideSpecial: passwordDataV0.OverrideSpecial,
 		Result:          passwordDataV0.Result,
 		ID:              passwordDataV0.ID,
 	}
 
-	hash, err := generateHash(passwordDataV3.Result.Value)
+	hash, err := generateHash(passwordDataV4.Result.Value)
 	if err != nil {
 		resp.Diagnostics.Append(diagnostics.HashGenerationError(err.Error())...)
 		return
 	}
 
-	passwordDataV3.BcryptHash.Value = hash
+	passwordDataV4.BcryptHash.Value = hash
 
-	diags := resp.State.Set(ctx, passwordDataV3)
+	diags := resp.State.Set(ctx, passwordDataV4)
 	resp.Diagnostics.Append(diags...)
 }
 
-func upgradePasswordStateV1toV3(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+func upgradePasswordStateV1toV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	type modelV1 struct {
 		ID              types.String `tfsdk:"id"`
 		Keepers         types.Map    `tfsdk:"keepers"`
@@ -236,29 +304,110 @@ func upgradePasswordStateV1toV3(ctx context.Context, req resource.UpgradeStateRe
 		return
 	}
 
-	passwordDataV3 := passwordModelV3{
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := passwordDataV1.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(passwordDataV1.Result.Value))
+	}
+
+	minNumeric := passwordDataV1.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := passwordDataV1.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := passwordDataV1.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := passwordDataV1.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := passwordDataV1.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := passwordDataV1.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := passwordDataV1.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := passwordDataV1.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	passwordDataV4 := passwordModelV4{
 		Keepers:         passwordDataV1.Keepers,
-		Length:          passwordDataV1.Length,
-		Special:         passwordDataV1.Special,
-		Upper:           passwordDataV1.Upper,
-		Lower:           passwordDataV1.Lower,
-		Number:          passwordDataV1.Number,
-		Numeric:         passwordDataV1.Number,
-		MinNumeric:      passwordDataV1.MinNumeric,
-		MinUpper:        passwordDataV1.MinUpper,
-		MinLower:        passwordDataV1.MinLower,
-		MinSpecial:      passwordDataV1.MinSpecial,
+		Length:          length,
+		Special:         special,
+		Upper:           upper,
+		Lower:           lower,
+		Number:          number,
+		Numeric:         number,
+		MinNumeric:      minNumeric,
+		MinUpper:        minUpper,
+		MinLower:        minLower,
+		MinSpecial:      minSpecial,
 		OverrideSpecial: passwordDataV1.OverrideSpecial,
 		BcryptHash:      passwordDataV1.BcryptHash,
 		Result:          passwordDataV1.Result,
 		ID:              passwordDataV1.ID,
 	}
 
-	diags := resp.State.Set(ctx, passwordDataV3)
+	diags := resp.State.Set(ctx, passwordDataV4)
 	resp.Diagnostics.Append(diags...)
 }
 
-func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+func upgradePasswordStateV2toV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	type passwordModelV2 struct {
+		ID              types.String `tfsdk:"id"`
+		Keepers         types.Map    `tfsdk:"keepers"`
+		Length          types.Int64  `tfsdk:"length"`
+		Special         types.Bool   `tfsdk:"special"`
+		Upper           types.Bool   `tfsdk:"upper"`
+		Lower           types.Bool   `tfsdk:"lower"`
+		Number          types.Bool   `tfsdk:"number"`
+		Numeric         types.Bool   `tfsdk:"numeric"`
+		MinNumeric      types.Int64  `tfsdk:"min_numeric"`
+		MinUpper        types.Int64  `tfsdk:"min_upper"`
+		MinLower        types.Int64  `tfsdk:"min_lower"`
+		MinSpecial      types.Int64  `tfsdk:"min_special"`
+		OverrideSpecial types.String `tfsdk:"override_special"`
+		Result          types.String `tfsdk:"result"`
+		BcryptHash      types.String `tfsdk:"bcrypt_hash"`
+	}
+
 	var passwordDataV2 passwordModelV2
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &passwordDataV2)...)
@@ -267,30 +416,100 @@ func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRe
 		return
 	}
 
-	// Schema version 2 to schema version 3 is a duplicate of the data,
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := passwordDataV2.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(passwordDataV2.Result.Value))
+	}
+
+	minNumeric := passwordDataV2.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := passwordDataV2.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := passwordDataV2.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := passwordDataV2.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := passwordDataV2.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := passwordDataV2.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := passwordDataV2.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := passwordDataV2.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	numeric := passwordDataV2.Number
+
+	if numeric.IsNull() {
+		numeric.Null = false
+		numeric.Value = true
+	}
+
+	// Schema version 2 to schema version 4 is a duplicate of the data,
 	// however the BcryptHash value may have been incorrectly generated.
-	//nolint:gosimple // V3 model will expand over time so all fields are written out to help future code changes.
-	passwordDataV3 := passwordModelV3{
+	//nolint:gosimple // V4 model will expand over time so all fields are written out to help future code changes.
+	passwordDataV4 := passwordModelV4{
 		BcryptHash:      passwordDataV2.BcryptHash,
 		ID:              passwordDataV2.ID,
 		Keepers:         passwordDataV2.Keepers,
-		Length:          passwordDataV2.Length,
-		Lower:           passwordDataV2.Lower,
-		MinLower:        passwordDataV2.MinLower,
-		MinNumeric:      passwordDataV2.MinNumeric,
-		MinSpecial:      passwordDataV2.MinSpecial,
-		MinUpper:        passwordDataV2.MinUpper,
-		Number:          passwordDataV2.Number,
-		Numeric:         passwordDataV2.Numeric,
+		Length:          length,
+		Lower:           lower,
+		MinLower:        minLower,
+		MinNumeric:      minNumeric,
+		MinSpecial:      minSpecial,
+		MinUpper:        minUpper,
+		Number:          number,
+		Numeric:         numeric,
 		OverrideSpecial: passwordDataV2.OverrideSpecial,
 		Result:          passwordDataV2.Result,
-		Special:         passwordDataV2.Special,
-		Upper:           passwordDataV2.Upper,
+		Special:         special,
+		Upper:           upper,
 	}
 
 	// Set the duplicated data now so we can easily return early below.
 	// The BcryptHash value will be adjusted later if it is incorrect.
-	resp.Diagnostics.Append(resp.State.Set(ctx, passwordDataV3)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, passwordDataV4)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -328,15 +547,325 @@ func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRe
 		return
 	}
 
-	passwordDataV3.BcryptHash.Value = string(newBcryptHash)
+	passwordDataV4.BcryptHash.Value = string(newBcryptHash)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, passwordDataV3)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, passwordDataV4)...)
+}
+
+func upgradePasswordStateV3toV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	type passwordModelV3 struct {
+		ID              types.String `tfsdk:"id"`
+		Keepers         types.Map    `tfsdk:"keepers"`
+		Length          types.Int64  `tfsdk:"length"`
+		Special         types.Bool   `tfsdk:"special"`
+		Upper           types.Bool   `tfsdk:"upper"`
+		Lower           types.Bool   `tfsdk:"lower"`
+		Number          types.Bool   `tfsdk:"number"`
+		Numeric         types.Bool   `tfsdk:"numeric"`
+		MinNumeric      types.Int64  `tfsdk:"min_numeric"`
+		MinUpper        types.Int64  `tfsdk:"min_upper"`
+		MinLower        types.Int64  `tfsdk:"min_lower"`
+		MinSpecial      types.Int64  `tfsdk:"min_special"`
+		OverrideSpecial types.String `tfsdk:"override_special"`
+		Result          types.String `tfsdk:"result"`
+		BcryptHash      types.String `tfsdk:"bcrypt_hash"`
+	}
+
+	var passwordDataV3 passwordModelV3
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &passwordDataV3)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := passwordDataV3.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(passwordDataV3.Result.Value))
+	}
+
+	minNumeric := passwordDataV3.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := passwordDataV3.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := passwordDataV3.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := passwordDataV3.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := passwordDataV3.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := passwordDataV3.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := passwordDataV3.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := passwordDataV3.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	numeric := passwordDataV3.Number
+
+	if numeric.IsNull() {
+		numeric.Null = false
+		numeric.Value = true
+	}
+
+	// Schema version 3 to schema version 4 is a duplicate of the data,
+	// however the .
+
+	//nolint:gosimple // V4 model will expand over time so all fields are written out to help future code changes.
+	passwordDataV4 := passwordModelV4{
+		BcryptHash:      passwordDataV3.BcryptHash,
+		ID:              passwordDataV3.ID,
+		Keepers:         passwordDataV3.Keepers,
+		Length:          length,
+		Lower:           lower,
+		MinLower:        minLower,
+		MinNumeric:      minNumeric,
+		MinSpecial:      minSpecial,
+		MinUpper:        minUpper,
+		Number:          number,
+		Numeric:         numeric,
+		OverrideSpecial: passwordDataV3.OverrideSpecial,
+		Result:          passwordDataV3.Result,
+		Special:         special,
+		Upper:           upper,
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, passwordDataV4)...)
 }
 
 func generateHash(toHash string) (string, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(toHash), bcrypt.DefaultCost)
 
 	return string(hash), err
+}
+
+func passwordSchemaV4() tfsdk.Schema {
+	return tfsdk.Schema{
+		Version: 4,
+		Description: "Identical to [random_string](string.html) with the exception that the result is " +
+			"treated as sensitive and, thus, _not_ displayed in console output. Read more about sensitive " +
+			"data handling in the " +
+			"[Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html).\n\n" +
+			"This resource *does* use a cryptographic random number generator.",
+		Attributes: map[string]tfsdk.Attribute{
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of " +
+					"resource. See [the main provider documentation](../index.html) for more information.",
+				Type: types.MapType{
+					ElemType: types.StringType,
+				},
+				Optional: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.RequiresReplaceIfValuesNotNull(),
+				},
+			},
+
+			"length": {
+				Description: "The length of the string desired. The minimum value for length is 1 and, length " +
+					"must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).",
+				Type:     types.Int64Type,
+				Required: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.RequiresReplace(),
+				},
+				Validators: []tfsdk.AttributeValidator{
+					int64validator.AtLeast(1),
+					int64validator.AtLeastSumOf(
+						path.MatchRoot("min_upper"),
+						path.MatchRoot("min_lower"),
+						path.MatchRoot("min_numeric"),
+						path.MatchRoot("min_special"),
+					),
+				},
+			},
+
+			"special": {
+				Description: "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"upper": {
+				Description: "Include uppercase alphabet characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"lower": {
+				Description: "Include lowercase alphabet characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"number": {
+				Description: "Include numeric characters in the result. Default value is `true`. " +
+					"**NOTE**: This is deprecated, use `numeric` instead.",
+				Type:     types.BoolType,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+				DeprecationMessage: "**NOTE**: This is deprecated, use `numeric` instead.",
+			},
+
+			"numeric": {
+				Description: "Include numeric characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_numeric": {
+				Description: "Minimum number of numeric characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_upper": {
+				Description: "Minimum number of uppercase alphabet characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_lower": {
+				Description: "Minimum number of lowercase alphabet characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_special": {
+				Description: "Minimum number of special characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"override_special": {
+				Description: "Supply your own list of special characters to use for string generation.  This " +
+					"overrides the default character list in the special argument.  The `special` argument must " +
+					"still be set to true for any overwritten characters to be used in generation.",
+				Type:     types.StringType,
+				Optional: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.RequiresReplaceIf(
+						planmodifiers.RequiresReplaceUnlessEmptyStringToNull(),
+						"Replace on modification unless updating from empty string (\"\") to null.",
+						"Replace on modification unless updating from empty string (`\"\"`) to `null`.",
+					),
+				},
+			},
+
+			"result": {
+				Description: "The generated random string.",
+				Type:        types.StringType,
+				Computed:    true,
+				Sensitive:   true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
+
+			"bcrypt_hash": {
+				Description: "A bcrypt hash of the generated random string.",
+				Type:        types.StringType,
+				Computed:    true,
+				Sensitive:   true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
+
+			"id": {
+				Description: "A static value used internally by Terraform, this should not be referenced in configurations.",
+				Computed:    true,
+				Type:        types.StringType,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
+		},
+	}
 }
 
 func passwordSchemaV3() tfsdk.Schema {
@@ -1025,25 +1554,7 @@ func passwordSchemaV0() tfsdk.Schema {
 	}
 }
 
-type passwordModelV3 struct {
-	ID              types.String `tfsdk:"id"`
-	Keepers         types.Map    `tfsdk:"keepers"`
-	Length          types.Int64  `tfsdk:"length"`
-	Special         types.Bool   `tfsdk:"special"`
-	Upper           types.Bool   `tfsdk:"upper"`
-	Lower           types.Bool   `tfsdk:"lower"`
-	Number          types.Bool   `tfsdk:"number"`
-	Numeric         types.Bool   `tfsdk:"numeric"`
-	MinNumeric      types.Int64  `tfsdk:"min_numeric"`
-	MinUpper        types.Int64  `tfsdk:"min_upper"`
-	MinLower        types.Int64  `tfsdk:"min_lower"`
-	MinSpecial      types.Int64  `tfsdk:"min_special"`
-	OverrideSpecial types.String `tfsdk:"override_special"`
-	Result          types.String `tfsdk:"result"`
-	BcryptHash      types.String `tfsdk:"bcrypt_hash"`
-}
-
-type passwordModelV2 struct {
+type passwordModelV4 struct {
 	ID              types.String `tfsdk:"id"`
 	Keepers         types.Map    `tfsdk:"keepers"`
 	Length          types.Int64  `tfsdk:"length"`

--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -269,7 +269,6 @@ func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRe
 
 	// Schema version 2 to schema version 3 is a duplicate of the data,
 	// however the BcryptHash value may have been incorrectly generated.
-
 	//nolint:gosimple // V3 model will expand over time so all fields are written out to help future code changes.
 	passwordDataV3 := passwordModelV3{
 		BcryptHash:      passwordDataV2.BcryptHash,

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -15,8 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-random/internal/random"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/terraform-providers/terraform-provider-random/internal/random"
 )
 
 func TestGenerateHash(t *testing.T) {
@@ -271,6 +272,201 @@ func TestAccResourcePassword_OverrideSpecial_FromVersion3_4_2(t *testing.T) {
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("random_password.test", "override_special"),
+					testExtractResourceAttr("random_password.test", "result", &result2),
+					testCheckAttributeValuesEqual(&result1, &result2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourcePassword_Import_FromVersion3_1_3 verifies behaviour when resource has been imported and stores
+// null for length, lower, number, special, upper, min_lower, min_numeric, min_special, min_upper attributes in state.
+// v3.1.3 was selected as this is the last provider version using schema version 0.
+func TestAccResourcePassword_Import_FromVersion3_1_3(t *testing.T) {
+	var result1, result2 string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: providerVersion313(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_password.test", "result", &result1),
+				),
+			},
+			{
+				ExternalProviders: providerVersion313(),
+				ResourceName:      "random_password.test",
+				// Usage of ImportStateIdFunc is required as the value passed to the `terraform import` command needs
+				// to be the password itself, as the password resource sets ID to "none" and "result" to the password
+				// supplied during import.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id := "random_password.test"
+					rs, ok := s.RootModule().Resources[id]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", id)
+					}
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("no ID is set")
+					}
+
+					return rs.Primary.Attributes["result"], nil
+				},
+				ImportState: true,
+				// These checks should fail as running terraform import with v3.1.3 stores null for result and number
+				// attributes in state.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					resource.TestCheckResourceAttr("random_password.test", "number", "true"),
+				),
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_password" "test" {
+					length = 12
+				}`,
+				PlanOnly: true,
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_password.test", "result", &result2),
+					testCheckAttributeValuesEqual(&result1, &result2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourcePassword_Import_FromVersion3_2_0 verifies behaviour when resource has been imported and stores
+// null for length, lower, number, special, upper, min_lower, min_numeric, min_special, min_upper attributes in state.
+// v3.2.0 was selected as this is the last provider version using schema version 1.
+func TestAccResourcePassword_Import_FromVersion3_2_0(t *testing.T) {
+	var result1, result2 string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: providerVersion320(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_password.test", "result", &result1),
+				),
+			},
+			{
+				ExternalProviders: providerVersion320(),
+				ResourceName:      "random_password.test",
+				// Usage of ImportStateIdFunc is required as the value passed to the `terraform import` command needs
+				// to be the password itself, as the password resource sets ID to "none" and "result" to the password
+				// supplied during import.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id := "random_password.test"
+					rs, ok := s.RootModule().Resources[id]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", id)
+					}
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("no ID is set")
+					}
+
+					return rs.Primary.Attributes["result"], nil
+				},
+				ImportState: true,
+				// These checks should fail as running terraform import with v3.2.0 stores null for result and number
+				// attributes in state.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					resource.TestCheckResourceAttr("random_password.test", "number", "true"),
+				),
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_password" "test" {
+					length = 12
+				}`,
+				PlanOnly: true,
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_password.test", "result", &result2),
+					testCheckAttributeValuesEqual(&result1, &result2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourcePassword_Import_FromVersion3_2_0 verifies behaviour when resource has been imported and stores
+// empty map {} for keepers and empty string for override_special in state.
+// v3.4.2 was selected as this is the last provider version using schema version 2.
+func TestAccResourcePassword_Import_FromVersion3_4_2(t *testing.T) {
+	var result1, result2 string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: providerVersion342(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_password.test", "result", &result1),
+				),
+			},
+			{
+				ExternalProviders: providerVersion342(),
+				ResourceName:      "random_password.test",
+				// Usage of ImportStateIdFunc is required as the value passed to the `terraform import` command needs
+				// to be the password itself, as the password resource sets ID to "none" and "result" to the password
+				// supplied during import.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id := "random_password.test"
+					rs, ok := s.RootModule().Resources[id]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", id)
+					}
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("no ID is set")
+					}
+
+					return rs.Primary.Attributes["result"], nil
+				},
+				ImportState: true,
+				// These checks should fail as running terraform import with v3.2.0 stores null for result and number
+				// attributes in state.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
+					resource.TestCheckResourceAttr("random_password.test", "override_special", ""),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_password" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
 					testExtractResourceAttr("random_password.test", "result", &result2),
 					testCheckAttributeValuesEqual(&result1, &result2),
 				),
@@ -941,7 +1137,9 @@ func TestAccResourcePassword_UpgradeFromVersion3_3_2(t *testing.T) {
 	})
 }
 
-func TestUpgradePasswordStateV0toV3(t *testing.T) {
+func TestUpgradePasswordStateV0toV4(t *testing.T) {
+	t.Parallel()
+
 	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
 		"id":               tftypes.NewValue(tftypes.String, "none"),
 		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
@@ -967,13 +1165,13 @@ func TestUpgradePasswordStateV0toV3(t *testing.T) {
 
 	resp := &res.UpgradeStateResponse{
 		State: tfsdk.State{
-			Schema: passwordSchemaV3(),
+			Schema: passwordSchemaV4(),
 		},
 	}
 
-	upgradePasswordStateV0toV3(context.Background(), req, resp)
+	upgradePasswordStateV0toV4(context.Background(), req, resp)
 
-	expected := passwordModelV3{
+	expected := passwordModelV4{
 		ID:              types.String{Value: "none"},
 		Keepers:         types.Map{Null: true, ElemType: types.StringType},
 		Length:          types.Int64{Value: 16},
@@ -990,7 +1188,7 @@ func TestUpgradePasswordStateV0toV3(t *testing.T) {
 		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
 	}
 
-	actual := passwordModelV3{}
+	actual := passwordModelV4{}
 	diags := resp.State.Get(context.Background(), &actual)
 	if diags.HasError() {
 		t.Errorf("error getting state: %v", diags)
@@ -1009,7 +1207,79 @@ func TestUpgradePasswordStateV0toV3(t *testing.T) {
 	}
 }
 
-func TestUpgradePasswordStateV1toV3(t *testing.T) {
+func TestUpgradePasswordStateV0toV4_NullValues(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, nil),
+		"lower":            tftypes.NewValue(tftypes.Bool, nil),
+		"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+		"min_special":      tftypes.NewValue(tftypes.Number, nil),
+		"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+		"number":           tftypes.NewValue(tftypes.Bool, nil),
+		"override_special": tftypes.NewValue(tftypes.String, nil),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, nil),
+		"upper":            tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: passwordSchemaV0(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: passwordSchemaV4(),
+		},
+	}
+
+	upgradePasswordStateV0toV4(context.Background(), req, resp)
+
+	expected := passwordModelV4{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Null: true},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := passwordModelV4{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	err := bcrypt.CompareHashAndPassword([]byte(actual.BcryptHash.Value), []byte(actual.Result.Value))
+	if err != nil {
+		t.Errorf("unexpected bcrypt comparison error: %s", err)
+	}
+
+	// Setting actual.BcryptHash to zero value to allow direct comparison of expected and actual.
+	actual.BcryptHash = types.String{}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradePasswordStateV1toV4(t *testing.T) {
+	t.Parallel()
+
 	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
 		"id":               tftypes.NewValue(tftypes.String, "none"),
 		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
@@ -1036,13 +1306,13 @@ func TestUpgradePasswordStateV1toV3(t *testing.T) {
 
 	resp := &res.UpgradeStateResponse{
 		State: tfsdk.State{
-			Schema: passwordSchemaV3(),
+			Schema: passwordSchemaV4(),
 		},
 	}
 
-	upgradePasswordStateV1toV3(context.Background(), req, resp)
+	upgradePasswordStateV1toV4(context.Background(), req, resp)
 
-	expected := passwordModelV3{
+	expected := passwordModelV4{
 		ID:              types.String{Value: "none"},
 		Keepers:         types.Map{Null: true, ElemType: types.StringType},
 		Length:          types.Int64{Value: 16},
@@ -1060,7 +1330,7 @@ func TestUpgradePasswordStateV1toV3(t *testing.T) {
 		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
 	}
 
-	actual := passwordModelV3{}
+	actual := passwordModelV4{}
 	diags := resp.State.Get(context.Background(), &actual)
 	if diags.HasError() {
 		t.Errorf("error getting state: %v", diags)
@@ -1071,7 +1341,71 @@ func TestUpgradePasswordStateV1toV3(t *testing.T) {
 	}
 }
 
-func TestUpgradePasswordStateV2toV3(t *testing.T) {
+func TestUpgradePasswordStateV1toV4_NullValues(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, nil),
+		"lower":            tftypes.NewValue(tftypes.Bool, nil),
+		"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+		"min_special":      tftypes.NewValue(tftypes.Number, nil),
+		"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+		"number":           tftypes.NewValue(tftypes.Bool, nil),
+		"override_special": tftypes.NewValue(tftypes.String, nil),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, nil),
+		"upper":            tftypes.NewValue(tftypes.Bool, nil),
+		"bcrypt_hash":      tftypes.NewValue(tftypes.String, "bcrypt_hash"),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: passwordSchemaV1(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: passwordSchemaV4(),
+		},
+	}
+
+	upgradePasswordStateV1toV4(context.Background(), req, resp)
+
+	expected := passwordModelV4{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Null: true},
+		BcryptHash:      types.String{Value: "bcrypt_hash"},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := passwordModelV4{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradePasswordStateV2toV4(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
@@ -1158,7 +1492,7 @@ func TestUpgradePasswordStateV2toV3(t *testing.T) {
 						"special":          tftypes.NewValue(tftypes.Bool, true),
 						"upper":            tftypes.NewValue(tftypes.Bool, true),
 					}),
-					Schema: passwordSchemaV3(),
+					Schema: passwordSchemaV4(),
 				},
 			},
 		},
@@ -1242,7 +1576,91 @@ func TestUpgradePasswordStateV2toV3(t *testing.T) {
 						"special":          tftypes.NewValue(tftypes.Bool, true),
 						"upper":            tftypes.NewValue(tftypes.Bool, true),
 					}),
-					Schema: passwordSchemaV3(),
+					Schema: passwordSchemaV4(),
+				},
+			},
+		},
+		"valid-hash-null-values": {
+			request: res.UpgradeStateRequest{
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"bcrypt_hash":      tftypes.String,
+							"id":               tftypes.String,
+							"keepers":          tftypes.Map{ElementType: tftypes.String},
+							"length":           tftypes.Number,
+							"lower":            tftypes.Bool,
+							"min_lower":        tftypes.Number,
+							"min_numeric":      tftypes.Number,
+							"min_special":      tftypes.Number,
+							"min_upper":        tftypes.Number,
+							"number":           tftypes.Bool,
+							"numeric":          tftypes.Bool,
+							"override_special": tftypes.String,
+							"result":           tftypes.String,
+							"special":          tftypes.Bool,
+							"upper":            tftypes.Bool,
+						},
+					}, map[string]tftypes.Value{
+						"bcrypt_hash":      tftypes.NewValue(tftypes.String, "$2a$10$d9zhEkVg.O1jZ6fEIMRlRuu/vMa0/4UIzeK5joaTBhZJlYiIPhWWa"),
+						"id":               tftypes.NewValue(tftypes.String, "none"),
+						"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+						"length":           tftypes.NewValue(tftypes.Number, nil),
+						"lower":            tftypes.NewValue(tftypes.Bool, nil),
+						"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+						"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+						"min_special":      tftypes.NewValue(tftypes.Number, nil),
+						"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+						"number":           tftypes.NewValue(tftypes.Bool, nil),
+						"numeric":          tftypes.NewValue(tftypes.Bool, nil),
+						"override_special": tftypes.NewValue(tftypes.String, ""),
+						"result":           tftypes.NewValue(tftypes.String, "n:um[a9kO&x!L=9og[EM"),
+						"special":          tftypes.NewValue(tftypes.Bool, nil),
+						"upper":            tftypes.NewValue(tftypes.Bool, nil),
+					}),
+					Schema: passwordSchemaV2(),
+				},
+			},
+			expected: &res.UpgradeStateResponse{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"bcrypt_hash":      tftypes.String,
+							"id":               tftypes.String,
+							"keepers":          tftypes.Map{ElementType: tftypes.String},
+							"length":           tftypes.Number,
+							"lower":            tftypes.Bool,
+							"min_lower":        tftypes.Number,
+							"min_numeric":      tftypes.Number,
+							"min_special":      tftypes.Number,
+							"min_upper":        tftypes.Number,
+							"number":           tftypes.Bool,
+							"numeric":          tftypes.Bool,
+							"override_special": tftypes.String,
+							"result":           tftypes.String,
+							"special":          tftypes.Bool,
+							"upper":            tftypes.Bool,
+						},
+					}, map[string]tftypes.Value{
+						// The difference checking should compare this actual
+						// value since it should not be updated.
+						"bcrypt_hash":      tftypes.NewValue(tftypes.String, "$2a$10$d9zhEkVg.O1jZ6fEIMRlRuu/vMa0/4UIzeK5joaTBhZJlYiIPhWWa"),
+						"id":               tftypes.NewValue(tftypes.String, "none"),
+						"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+						"length":           tftypes.NewValue(tftypes.Number, 20),
+						"lower":            tftypes.NewValue(tftypes.Bool, true),
+						"min_lower":        tftypes.NewValue(tftypes.Number, 0),
+						"min_numeric":      tftypes.NewValue(tftypes.Number, 0),
+						"min_special":      tftypes.NewValue(tftypes.Number, 0),
+						"min_upper":        tftypes.NewValue(tftypes.Number, 0),
+						"number":           tftypes.NewValue(tftypes.Bool, true),
+						"numeric":          tftypes.NewValue(tftypes.Bool, true),
+						"override_special": tftypes.NewValue(tftypes.String, ""),
+						"result":           tftypes.NewValue(tftypes.String, "n:um[a9kO&x!L=9og[EM"),
+						"special":          tftypes.NewValue(tftypes.Bool, true),
+						"upper":            tftypes.NewValue(tftypes.Bool, true),
+					}),
+					Schema: passwordSchemaV4(),
 				},
 			},
 		},
@@ -1260,7 +1678,7 @@ func TestUpgradePasswordStateV2toV3(t *testing.T) {
 				},
 			}
 
-			upgradePasswordStateV2toV3(context.Background(), testCase.request, &got)
+			upgradePasswordStateV2toV4(context.Background(), testCase.request, &got)
 
 			// Since bcrypt_hash is generated, this test is very involved to
 			// ensure the test case is set up properly and the generated
@@ -1378,6 +1796,136 @@ func TestUpgradePasswordStateV2toV3(t *testing.T) {
 				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
+	}
+}
+
+func TestUpgradePasswordStateV3toV4(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, 16),
+		"lower":            tftypes.NewValue(tftypes.Bool, true),
+		"min_lower":        tftypes.NewValue(tftypes.Number, 0),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, 0),
+		"min_special":      tftypes.NewValue(tftypes.Number, 0),
+		"min_upper":        tftypes.NewValue(tftypes.Number, 0),
+		"number":           tftypes.NewValue(tftypes.Bool, true),
+		"numeric":          tftypes.NewValue(tftypes.Bool, true),
+		"override_special": tftypes.NewValue(tftypes.String, "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, true),
+		"upper":            tftypes.NewValue(tftypes.Bool, true),
+		"bcrypt_hash":      tftypes.NewValue(tftypes.String, "bcrypt_hash"),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: passwordSchemaV3(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: passwordSchemaV4(),
+		},
+	}
+
+	upgradePasswordStateV3toV4(context.Background(), req, resp)
+
+	expected := passwordModelV4{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Value: "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"},
+		BcryptHash:      types.String{Value: "bcrypt_hash"},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := passwordModelV4{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradePasswordStateV3toV4_NullValues(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, nil),
+		"lower":            tftypes.NewValue(tftypes.Bool, true),
+		"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+		"min_special":      tftypes.NewValue(tftypes.Number, nil),
+		"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+		"number":           tftypes.NewValue(tftypes.Bool, nil),
+		"numeric":          tftypes.NewValue(tftypes.Bool, nil),
+		"override_special": tftypes.NewValue(tftypes.String, "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, nil),
+		"upper":            tftypes.NewValue(tftypes.Bool, nil),
+		"bcrypt_hash":      tftypes.NewValue(tftypes.String, "bcrypt_hash"),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: passwordSchemaV3(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: passwordSchemaV4(),
+		},
+	}
+
+	upgradePasswordStateV3toV4(context.Background(), req, resp)
+
+	expected := passwordModelV4{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Value: "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"},
+		BcryptHash:      types.String{Value: "bcrypt_hash"},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := passwordModelV4{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
 	}
 }
 

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -64,7 +64,7 @@ func TestGenerateHash(t *testing.T) {
 	}
 }
 
-func TestAccResourcePassword(t *testing.T) {
+func TestAccResourcePassword_Import(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_string.go
+++ b/internal/provider/resource_string.go
@@ -21,6 +21,338 @@ var _ provider.ResourceType = (*stringResourceType)(nil)
 type stringResourceType struct{}
 
 func (r stringResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return stringSchemaV3(), nil
+}
+
+func (r stringResourceType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
+	return &stringResource{}, nil
+}
+
+var (
+	_ resource.Resource                 = (*stringResource)(nil)
+	_ resource.ResourceWithImportState  = (*stringResource)(nil)
+	_ resource.ResourceWithUpgradeState = (*stringResource)(nil)
+)
+
+type stringResource struct{}
+
+func (r *stringResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan stringModelV3
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	params := random.StringParams{
+		Length:          plan.Length.Value,
+		Upper:           plan.Upper.Value,
+		MinUpper:        plan.MinUpper.Value,
+		Lower:           plan.Lower.Value,
+		MinLower:        plan.MinLower.Value,
+		Numeric:         plan.Numeric.Value,
+		MinNumeric:      plan.MinNumeric.Value,
+		Special:         plan.Special.Value,
+		MinSpecial:      plan.MinSpecial.Value,
+		OverrideSpecial: plan.OverrideSpecial.Value,
+	}
+
+	result, err := random.CreateString(params)
+	if err != nil {
+		resp.Diagnostics.Append(diagnostics.RandomReadError(err.Error())...)
+		return
+	}
+
+	plan.ID = types.String{Value: string(result)}
+	plan.Result = types.String{Value: string(result)}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+// Read does not need to perform any operations as the state in ReadResourceResponse is already populated.
+func (r *stringResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+// Update ensures the plan value is copied to the state to complete the update.
+func (r *stringResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var model stringModelV3
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+// Delete does not need to explicitly call resp.State.RemoveResource() as this is automatically handled by the
+// [framework](https://github.com/hashicorp/terraform-plugin-framework/pull/301).
+func (r *stringResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func (r *stringResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id := req.ID
+
+	state := stringModelV3{
+		ID:         types.String{Value: id},
+		Result:     types.String{Value: id},
+		Length:     types.Int64{Value: int64(len(id))},
+		Special:    types.Bool{Value: true},
+		Upper:      types.Bool{Value: true},
+		Lower:      types.Bool{Value: true},
+		Number:     types.Bool{Value: true},
+		Numeric:    types.Bool{Value: true},
+		MinSpecial: types.Int64{Value: 0},
+		MinUpper:   types.Int64{Value: 0},
+		MinLower:   types.Int64{Value: 0},
+		MinNumeric: types.Int64{Value: 0},
+	}
+
+	state.Keepers.ElemType = types.StringType
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *stringResource) UpgradeState(context.Context) map[int64]resource.StateUpgrader {
+	schemaV1 := stringSchemaV1()
+	schemaV2 := stringSchemaV2()
+
+	return map[int64]resource.StateUpgrader{
+		1: {
+			PriorSchema:   &schemaV1,
+			StateUpgrader: upgradeStringStateV1toV3,
+		},
+		2: {
+			PriorSchema:   &schemaV2,
+			StateUpgrader: upgradeStringStateV2toV3,
+		},
+	}
+}
+
+func upgradeStringStateV1toV3(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	type modelV1 struct {
+		ID              types.String `tfsdk:"id"`
+		Keepers         types.Map    `tfsdk:"keepers"`
+		Length          types.Int64  `tfsdk:"length"`
+		Special         types.Bool   `tfsdk:"special"`
+		Upper           types.Bool   `tfsdk:"upper"`
+		Lower           types.Bool   `tfsdk:"lower"`
+		Number          types.Bool   `tfsdk:"number"`
+		MinNumeric      types.Int64  `tfsdk:"min_numeric"`
+		MinUpper        types.Int64  `tfsdk:"min_upper"`
+		MinLower        types.Int64  `tfsdk:"min_lower"`
+		MinSpecial      types.Int64  `tfsdk:"min_special"`
+		OverrideSpecial types.String `tfsdk:"override_special"`
+		Result          types.String `tfsdk:"result"`
+	}
+
+	var stringDataV1 modelV1
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &stringDataV1)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := stringDataV1.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(stringDataV1.Result.Value))
+	}
+
+	minNumeric := stringDataV1.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := stringDataV1.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := stringDataV1.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := stringDataV1.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := stringDataV1.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := stringDataV1.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := stringDataV1.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := stringDataV1.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	stringDataV3 := stringModelV3{
+		Keepers:         stringDataV1.Keepers,
+		Length:          length,
+		Special:         special,
+		Upper:           upper,
+		Lower:           lower,
+		Number:          number,
+		Numeric:         number,
+		MinNumeric:      minNumeric,
+		MinUpper:        minUpper,
+		MinLower:        minLower,
+		MinSpecial:      minSpecial,
+		OverrideSpecial: stringDataV1.OverrideSpecial,
+		Result:          stringDataV1.Result,
+		ID:              stringDataV1.ID,
+	}
+
+	diags := resp.State.Set(ctx, stringDataV3)
+	resp.Diagnostics.Append(diags...)
+}
+
+func upgradeStringStateV2toV3(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	type modelV2 struct {
+		ID              types.String `tfsdk:"id"`
+		Keepers         types.Map    `tfsdk:"keepers"`
+		Length          types.Int64  `tfsdk:"length"`
+		Special         types.Bool   `tfsdk:"special"`
+		Upper           types.Bool   `tfsdk:"upper"`
+		Lower           types.Bool   `tfsdk:"lower"`
+		Number          types.Bool   `tfsdk:"number"`
+		Numeric         types.Bool   `tfsdk:"numeric"`
+		MinNumeric      types.Int64  `tfsdk:"min_numeric"`
+		MinUpper        types.Int64  `tfsdk:"min_upper"`
+		MinLower        types.Int64  `tfsdk:"min_lower"`
+		MinSpecial      types.Int64  `tfsdk:"min_special"`
+		OverrideSpecial types.String `tfsdk:"override_special"`
+		Result          types.String `tfsdk:"result"`
+	}
+
+	var stringDataV2 modelV2
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &stringDataV2)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Setting fields that can contain null to non-null to prevent forced replacement.
+	// This can occur in cases where import has been used in provider versions v3.3.1 and earlier.
+	// If import has been used with v3.3.1, for instance then length, lower, number, special, upper,
+	// min_lower, min_numeric, min_special and min_upper attributes will all be null in state.
+	length := stringDataV2.Length
+
+	if length.IsNull() {
+		length.Null = false
+		length.Value = int64(len(stringDataV2.Result.Value))
+	}
+
+	minNumeric := stringDataV2.MinNumeric
+
+	if minNumeric.IsNull() {
+		minNumeric.Null = false
+	}
+
+	minUpper := stringDataV2.MinUpper
+
+	if minUpper.IsNull() {
+		minUpper.Null = false
+	}
+
+	minLower := stringDataV2.MinLower
+
+	if minLower.IsNull() {
+		minLower.Null = false
+	}
+
+	minSpecial := stringDataV2.MinSpecial
+
+	if minSpecial.IsNull() {
+		minSpecial.Null = false
+	}
+
+	special := stringDataV2.Special
+
+	if special.IsNull() {
+		special.Null = false
+		special.Value = true
+	}
+
+	upper := stringDataV2.Upper
+
+	if upper.IsNull() {
+		upper.Null = false
+		upper.Value = true
+	}
+
+	lower := stringDataV2.Lower
+
+	if lower.IsNull() {
+		lower.Null = false
+		lower.Value = true
+	}
+
+	number := stringDataV2.Number
+
+	if number.IsNull() {
+		number.Null = false
+		number.Value = true
+	}
+
+	stringDataV3 := stringModelV3{
+		Keepers:         stringDataV2.Keepers,
+		Length:          length,
+		Special:         special,
+		Upper:           upper,
+		Lower:           lower,
+		Number:          number,
+		Numeric:         number,
+		MinNumeric:      minNumeric,
+		MinUpper:        minUpper,
+		MinLower:        minLower,
+		MinSpecial:      minSpecial,
+		OverrideSpecial: stringDataV2.OverrideSpecial,
+		Result:          stringDataV2.Result,
+		ID:              stringDataV2.ID,
+	}
+
+	diags := resp.State.Set(ctx, stringDataV3)
+	resp.Diagnostics.Append(diags...)
+}
+
+func stringSchemaV3() tfsdk.Schema {
 	return tfsdk.Schema{
 		Version: 2,
 		Description: "The resource `random_string` generates a random permutation of alphanumeric " +
@@ -195,109 +527,189 @@ func (r stringResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.Diagn
 				},
 			},
 		},
-	}, nil
-}
-
-func (r stringResourceType) NewResource(_ context.Context, p provider.Provider) (resource.Resource, diag.Diagnostics) {
-	return &stringResource{}, nil
-}
-
-var (
-	_ resource.Resource                 = (*stringResource)(nil)
-	_ resource.ResourceWithImportState  = (*stringResource)(nil)
-	_ resource.ResourceWithUpgradeState = (*stringResource)(nil)
-)
-
-type stringResource struct{}
-
-func (r *stringResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan stringModelV2
-
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
 	}
-
-	params := random.StringParams{
-		Length:          plan.Length.Value,
-		Upper:           plan.Upper.Value,
-		MinUpper:        plan.MinUpper.Value,
-		Lower:           plan.Lower.Value,
-		MinLower:        plan.MinLower.Value,
-		Numeric:         plan.Numeric.Value,
-		MinNumeric:      plan.MinNumeric.Value,
-		Special:         plan.Special.Value,
-		MinSpecial:      plan.MinSpecial.Value,
-		OverrideSpecial: plan.OverrideSpecial.Value,
-	}
-
-	result, err := random.CreateString(params)
-	if err != nil {
-		resp.Diagnostics.Append(diagnostics.RandomReadError(err.Error())...)
-		return
-	}
-
-	plan.ID = types.String{Value: string(result)}
-	plan.Result = types.String{Value: string(result)}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
-// Read does not need to perform any operations as the state in ReadResourceResponse is already populated.
-func (r *stringResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-}
+func stringSchemaV2() tfsdk.Schema {
+	return tfsdk.Schema{
+		Version: 2,
+		Description: "The resource `random_string` generates a random permutation of alphanumeric " +
+			"characters and optionally special characters.\n" +
+			"\n" +
+			"This resource *does* use a cryptographic random number generator.\n" +
+			"\n" +
+			"Historically this resource's intended usage has been ambiguous as the original example used " +
+			"it in a password. For backwards compatibility it will continue to exist. For unique ids please " +
+			"use [random_id](id.html), for sensitive random values please use [random_password](password.html).",
+		Attributes: map[string]tfsdk.Attribute{
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of " +
+					"resource. See [the main provider documentation](../index.html) for more information.",
+				Type: types.MapType{
+					ElemType: types.StringType,
+				},
+				Optional: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.RequiresReplaceIfValuesNotNull(),
+				},
+			},
 
-// Update ensures the plan value is copied to the state to complete the update.
-func (r *stringResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model stringModelV2
+			"length": {
+				Description: "The length of the string desired. The minimum value for length is 1 and, length " +
+					"must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).",
+				Type:          types.Int64Type,
+				Required:      true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{resource.RequiresReplace()},
+				Validators: []tfsdk.AttributeValidator{
+					int64validator.AtLeast(1),
+					int64validator.AtLeastSumOf(
+						path.MatchRoot("min_upper"),
+						path.MatchRoot("min_lower"),
+						path.MatchRoot("min_numeric"),
+						path.MatchRoot("min_special"),
+					),
+				},
+			},
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+			"special": {
+				Description: "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
 
-	if resp.Diagnostics.HasError() {
-		return
-	}
+			"upper": {
+				Description: "Include uppercase alphabet characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
-}
+			"lower": {
+				Description: "Include lowercase alphabet characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Bool{Value: true}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
 
-// Delete does not need to explicitly call resp.State.RemoveResource() as this is automatically handled by the
-// [framework](https://github.com/hashicorp/terraform-plugin-framework/pull/301).
-func (r *stringResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-}
+			"number": {
+				Description: "Include numeric characters in the result. Default value is `true`. " +
+					"**NOTE**: This is deprecated, use `numeric` instead.",
+				Type:     types.BoolType,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+				DeprecationMessage: "**NOTE**: This is deprecated, use `numeric` instead.",
+			},
 
-func (r *stringResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
+			"numeric": {
+				Description: "Include numeric characters in the result. Default value is `true`.",
+				Type:        types.BoolType,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.NumberNumericAttributePlanModifier(),
+					planmodifiers.RequiresReplace(),
+				},
+			},
 
-	state := stringModelV2{
-		ID:         types.String{Value: id},
-		Result:     types.String{Value: id},
-		Length:     types.Int64{Value: int64(len(id))},
-		Special:    types.Bool{Value: true},
-		Upper:      types.Bool{Value: true},
-		Lower:      types.Bool{Value: true},
-		Number:     types.Bool{Value: true},
-		Numeric:    types.Bool{Value: true},
-		MinSpecial: types.Int64{Value: 0},
-		MinUpper:   types.Int64{Value: 0},
-		MinLower:   types.Int64{Value: 0},
-		MinNumeric: types.Int64{Value: 0},
-		Keepers: types.Map{
-			ElemType: types.StringType,
-			Null:     true,
+			"min_numeric": {
+				Description: "Minimum number of numeric characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_upper": {
+				Description: "Minimum number of uppercase alphabet characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_lower": {
+				Description: "Minimum number of lowercase alphabet characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"min_special": {
+				Description: "Minimum number of special characters in the result. Default value is `0`.",
+				Type:        types.Int64Type,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					planmodifiers.DefaultValue(types.Int64{Value: 0}),
+					planmodifiers.RequiresReplace(),
+				},
+			},
+
+			"override_special": {
+				Description: "Supply your own list of special characters to use for string generation.  This " +
+					"overrides the default character list in the special argument.  The `special` argument must " +
+					"still be set to true for any overwritten characters to be used in generation.",
+				Type:     types.StringType,
+				Optional: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.RequiresReplaceIf(
+						planmodifiers.RequiresReplaceUnlessEmptyStringToNull(),
+						"Replace on modification unless updating from empty string (\"\") to null.",
+						"Replace on modification unless updating from empty string (`\"\"`) to `null`.",
+					),
+				},
+			},
+
+			"result": {
+				Description: "The generated random string.",
+				Type:        types.StringType,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
+
+			"id": {
+				Description: "The generated random string.",
+				Computed:    true,
+				Type:        types.StringType,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					resource.UseStateForUnknown(),
+				},
+			},
 		},
-		OverrideSpecial: types.String{Null: true},
-	}
-
-	diags := resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
 	}
 }
 
-func (r *stringResource) UpgradeState(context.Context) map[int64]resource.StateUpgrader {
-	schemaV1 := tfsdk.Schema{
+func stringSchemaV1() tfsdk.Schema {
+	return tfsdk.Schema{
 		Version: 1,
 		Description: "The resource `random_string` generates a random permutation of alphanumeric " +
 			"characters and optionally special characters.\n" +
@@ -450,61 +862,9 @@ func (r *stringResource) UpgradeState(context.Context) map[int64]resource.StateU
 			},
 		},
 	}
-
-	return map[int64]resource.StateUpgrader{
-		1: {
-			PriorSchema:   &schemaV1,
-			StateUpgrader: upgradeStringStateV1toV2,
-		},
-	}
 }
 
-func upgradeStringStateV1toV2(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	type modelV1 struct {
-		ID              types.String `tfsdk:"id"`
-		Keepers         types.Map    `tfsdk:"keepers"`
-		Length          types.Int64  `tfsdk:"length"`
-		Special         types.Bool   `tfsdk:"special"`
-		Upper           types.Bool   `tfsdk:"upper"`
-		Lower           types.Bool   `tfsdk:"lower"`
-		Number          types.Bool   `tfsdk:"number"`
-		MinNumeric      types.Int64  `tfsdk:"min_numeric"`
-		MinUpper        types.Int64  `tfsdk:"min_upper"`
-		MinLower        types.Int64  `tfsdk:"min_lower"`
-		MinSpecial      types.Int64  `tfsdk:"min_special"`
-		OverrideSpecial types.String `tfsdk:"override_special"`
-		Result          types.String `tfsdk:"result"`
-	}
-
-	var stringDataV1 modelV1
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &stringDataV1)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	stringDataV2 := stringModelV2{
-		Keepers:         stringDataV1.Keepers,
-		Length:          stringDataV1.Length,
-		Special:         stringDataV1.Special,
-		Upper:           stringDataV1.Upper,
-		Lower:           stringDataV1.Lower,
-		Number:          stringDataV1.Number,
-		Numeric:         stringDataV1.Number,
-		MinNumeric:      stringDataV1.MinNumeric,
-		MinUpper:        stringDataV1.MinUpper,
-		MinLower:        stringDataV1.MinLower,
-		MinSpecial:      stringDataV1.MinSpecial,
-		OverrideSpecial: stringDataV1.OverrideSpecial,
-		Result:          stringDataV1.Result,
-		ID:              stringDataV1.ID,
-	}
-
-	diags := resp.State.Set(ctx, stringDataV2)
-	resp.Diagnostics.Append(diags...)
-}
-
-type stringModelV2 struct {
+type stringModelV3 struct {
 	ID              types.String `tfsdk:"id"`
 	Keepers         types.Map    `tfsdk:"keepers"`
 	Length          types.Int64  `tfsdk:"length"`

--- a/internal/provider/resource_string.go
+++ b/internal/provider/resource_string.go
@@ -96,18 +96,20 @@ func (r *stringResource) ImportState(ctx context.Context, req resource.ImportSta
 	id := req.ID
 
 	state := stringModelV3{
-		ID:         types.String{Value: id},
-		Result:     types.String{Value: id},
-		Length:     types.Int64{Value: int64(len(id))},
-		Special:    types.Bool{Value: true},
-		Upper:      types.Bool{Value: true},
-		Lower:      types.Bool{Value: true},
-		Number:     types.Bool{Value: true},
-		Numeric:    types.Bool{Value: true},
-		MinSpecial: types.Int64{Value: 0},
-		MinUpper:   types.Int64{Value: 0},
-		MinLower:   types.Int64{Value: 0},
-		MinNumeric: types.Int64{Value: 0},
+		ID:              types.String{Value: id},
+		Result:          types.String{Value: id},
+		Length:          types.Int64{Value: int64(len(id))},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinSpecial:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinNumeric:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Null: true},
+		Keepers:         types.Map{Null: true},
 	}
 
 	state.Keepers.ElemType = types.StringType

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -1,11 +1,18 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	res "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceString(t *testing.T) {
@@ -1252,6 +1259,383 @@ func TestAccResourceString_UpgradeFromVersion3_3_2(t *testing.T) {
 					resource.TestCheckResourceAttr("random_string.min", "min_upper", "3"),
 					resource.TestCheckResourceAttr("random_string.min", "min_lower", "2"),
 					resource.TestCheckResourceAttr("random_string.min", "min_numeric", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestUpgradeStringStateV1toV3(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, 16),
+		"lower":            tftypes.NewValue(tftypes.Bool, true),
+		"min_lower":        tftypes.NewValue(tftypes.Number, 0),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, 0),
+		"min_special":      tftypes.NewValue(tftypes.Number, 0),
+		"min_upper":        tftypes.NewValue(tftypes.Number, 0),
+		"number":           tftypes.NewValue(tftypes.Bool, true),
+		"override_special": tftypes.NewValue(tftypes.String, "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, true),
+		"upper":            tftypes.NewValue(tftypes.Bool, true),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: stringSchemaV1(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: stringSchemaV3(),
+		},
+	}
+
+	upgradeStringStateV1toV3(context.Background(), req, resp)
+
+	expected := stringModelV3{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Value: "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := stringModelV3{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradeStringStateV1toV3_NullValues(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, nil),
+		"lower":            tftypes.NewValue(tftypes.Bool, nil),
+		"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+		"min_special":      tftypes.NewValue(tftypes.Number, nil),
+		"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+		"number":           tftypes.NewValue(tftypes.Bool, nil),
+		"override_special": tftypes.NewValue(tftypes.String, nil),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, nil),
+		"upper":            tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: stringSchemaV1(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: stringSchemaV3(),
+		},
+	}
+
+	upgradeStringStateV1toV3(context.Background(), req, resp)
+
+	expected := stringModelV3{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Null: true},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := stringModelV3{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradeStringStateV2toV3(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, 16),
+		"lower":            tftypes.NewValue(tftypes.Bool, true),
+		"min_lower":        tftypes.NewValue(tftypes.Number, 0),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, 0),
+		"min_special":      tftypes.NewValue(tftypes.Number, 0),
+		"min_upper":        tftypes.NewValue(tftypes.Number, 0),
+		"number":           tftypes.NewValue(tftypes.Bool, true),
+		"numeric":          tftypes.NewValue(tftypes.Bool, true),
+		"override_special": tftypes.NewValue(tftypes.String, "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, true),
+		"upper":            tftypes.NewValue(tftypes.Bool, true),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: stringSchemaV2(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: stringSchemaV3(),
+		},
+	}
+
+	upgradeStringStateV2toV3(context.Background(), req, resp)
+
+	expected := stringModelV3{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Value: "!#$%\u0026*()-_=+[]{}\u003c\u003e:?"},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := stringModelV3{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestUpgradeStringStateV2toV3_NullValues(t *testing.T) {
+	t.Parallel()
+
+	raw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+		"id":               tftypes.NewValue(tftypes.String, "none"),
+		"keepers":          tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+		"length":           tftypes.NewValue(tftypes.Number, nil),
+		"lower":            tftypes.NewValue(tftypes.Bool, nil),
+		"min_lower":        tftypes.NewValue(tftypes.Number, nil),
+		"min_numeric":      tftypes.NewValue(tftypes.Number, nil),
+		"min_special":      tftypes.NewValue(tftypes.Number, nil),
+		"min_upper":        tftypes.NewValue(tftypes.Number, nil),
+		"number":           tftypes.NewValue(tftypes.Bool, nil),
+		"numeric":          tftypes.NewValue(tftypes.Bool, nil),
+		"override_special": tftypes.NewValue(tftypes.String, nil),
+		"result":           tftypes.NewValue(tftypes.String, "DZy_3*tnonj%Q%Yx"),
+		"special":          tftypes.NewValue(tftypes.Bool, nil),
+		"upper":            tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := res.UpgradeStateRequest{
+		State: &tfsdk.State{
+			Raw:    raw,
+			Schema: stringSchemaV2(),
+		},
+	}
+
+	resp := &res.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: stringSchemaV3(),
+		},
+	}
+
+	upgradeStringStateV2toV3(context.Background(), req, resp)
+
+	expected := stringModelV3{
+		ID:              types.String{Value: "none"},
+		Keepers:         types.Map{Null: true, ElemType: types.StringType},
+		Length:          types.Int64{Value: 16},
+		Special:         types.Bool{Value: true},
+		Upper:           types.Bool{Value: true},
+		Lower:           types.Bool{Value: true},
+		Number:          types.Bool{Value: true},
+		Numeric:         types.Bool{Value: true},
+		MinNumeric:      types.Int64{Value: 0},
+		MinUpper:        types.Int64{Value: 0},
+		MinLower:        types.Int64{Value: 0},
+		MinSpecial:      types.Int64{Value: 0},
+		OverrideSpecial: types.String{Null: true},
+		Result:          types.String{Value: "DZy_3*tnonj%Q%Yx"},
+	}
+
+	actual := stringModelV3{}
+	diags := resp.State.Get(context.Background(), &actual)
+	if diags.HasError() {
+		t.Errorf("error getting state: %v", diags)
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+// TestAccResourcePassword_String_FromVersion3_1_3 verifies behaviour when resource has been imported and stores
+// null for length, lower, number, special, upper, min_lower, min_numeric, min_special, min_upper attributes in state.
+// v3.1.3 was selected as this is the last provider version using schema version 1.
+func TestAccResourceString_Import_FromVersion3_1_3(t *testing.T) {
+	var result1, result2 string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: providerVersion313(),
+				Config: `resource "random_string" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_string.test", "result", &result1),
+				),
+			},
+			{
+				ExternalProviders: providerVersion313(),
+				ResourceName:      "random_string.test",
+				// Usage of ImportStateIdFunc is required as the value passed to the `terraform import` command needs
+				// to be the password itself, as the password resource sets ID to "none" and "result" to the password
+				// supplied during import.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id := "random_string.test"
+					rs, ok := s.RootModule().Resources[id]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", id)
+					}
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("no ID is set")
+					}
+
+					return rs.Primary.Attributes["result"], nil
+				},
+				ImportState: true,
+				// These checks should fail as running terraform import with v3.1.3 stores null for result and number
+				// attributes in state.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					resource.TestCheckResourceAttr("random_string.test", "number", "true"),
+				),
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_string" "test" {
+					length = 12
+				}`,
+				PlanOnly: true,
+			},
+			{
+				// This test is not really verifying desired behaviour as the import is populating length, number etc
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_string" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_string.test", "result", &result2),
+					testCheckAttributeValuesEqual(&result1, &result2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceString_Import_FromVersion3_2_0 verifies behaviour when resource has been imported and stores
+// empty map {} for keepers and empty string for override_special in state.
+// v3.4.2 was selected as this is the last provider version using schema version 2.
+func TestAccResourceString_Import_FromVersion3_4_2(t *testing.T) {
+	var result1, result2 string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: providerVersion342(),
+				Config: `resource "random_string" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_string.test", "result", &result1),
+				),
+			},
+			{
+				ExternalProviders: providerVersion342(),
+				ResourceName:      "random_string.test",
+				// Usage of ImportStateIdFunc is required as the value passed to the `terraform import` command needs
+				// to be the password itself, as the password resource sets ID to "none" and "result" to the password
+				// supplied during import.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id := "random_string.test"
+					rs, ok := s.RootModule().Resources[id]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", id)
+					}
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("no ID is set")
+					}
+
+					return rs.Primary.Attributes["result"], nil
+				},
+				ImportState: true,
+				// These checks should fail as running terraform import with v3.2.0 stores null for result and number
+				// attributes in state.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					resource.TestCheckResourceAttr("random_string.test", "override_special", ""),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: protoV5ProviderFactories(),
+				Config: `resource "random_string" "test" {
+							length = 12
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("random_string.test", "result", testCheckLen(12)),
+					testExtractResourceAttr("random_string.test", "result", &result2),
+					testCheckAttributeValuesEqual(&result1, &result2),
 				),
 			},
 		},

--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccResourceString(t *testing.T) {
+func TestAccResourceString_Import(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
In the discussion contained in [Upgrade v2.2.1 -> v3.4.0 forces replacement](https://github.com/hashicorp/terraform-provider-random/issues/302#top) there were several comments indicating that a forced replacement was happening under some circumstances:

- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1233159123
- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1233263617
- https://github.com/hashicorp/terraform-provider-random/issues/302#issuecomment-1235611077

The attributes in question usually have a default value of `0` assigned (i.e., `min_lower`, `min_upper`, `min_numeric` and `min_special`) or `true` assigned (i.e., `lower`, `upper`, `number`, `numeric` and `special`) when no value for them is specified in the configuration.

However, under some circumstances, the attributes described can end up with a value of `null` assigned to them in the state which results in a forced update when _terraform apply_ is run.

One of the circumstances that can give rise to the storage of null values for these attributes is using _terraform import_ with a version of the provider that is `v3.3.1` or earlier. Under these circumstances, all of the attributes mentioned, along with `length` are assigned a value of `null` in state.

This PR aims to address this issue by implementing a state upgrader which interrogates each of the aforementioned attributes and assigns it a default value if the value currently held for the attribute in state is `null`.