### PR TITLE
Test updates to setup-terraform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Terraform ${{ matrix.terraform }}
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@73d00bf3fd8b34f69204a0dcef07598ba579bfd9
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false


### PR DESCRIPTION
Update setup-terraform to use sha containing bump of actions/core fro…m 1.9.1 to 1.10.0

This PR is just to verify that the modified version of `hashicorp/setup-terraform` runs successfully.