### PR TITLE
ci: merging `golangci-lint` rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,25 @@
-linters:
-  # Default linters enabled
-  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
 
-  # Additional linters enabled
+linters:
+  disable-all: true
   enable:
     - durationcheck
+    - errcheck
     - exportloopref
+    - forcetypeassert
     - godot
     - gofmt
+    - gosimple
+    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
+    - staticcheck
     - tenv
     - unconvert
     - unparam
+    - unused
+    - vet


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

### Notes
- Skipping `paralleltest` for the providers
