### PR TITLE
Prevent hash error `bcrypt.ErrPasswordTooLong` for passwords  > 72 bytes in length

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230412-132501.yaml
+++ b/.changes/unreleased/BUG FIXES-20230412-132501.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'resource/random_password: The `generateHash()` functions has been modified
+body: 'resource/random_password: The `generateHash()` function has been modified
   to truncate strings to 72 bytes'
 time: 2023-04-12T13:25:01.113462+01:00
 custom:

--- a/.changes/unreleased/BUG FIXES-20230412-132501.yaml
+++ b/.changes/unreleased/BUG FIXES-20230412-132501.yaml
@@ -1,6 +1,6 @@
 kind: BUG FIXES
-body: 'resource/random_password: The `generateHash()` function has been modified
-  to truncate strings to 72 bytes'
+body: 'resource/random_password: Prevent error with `bcrypt` by truncating the bytes
+  that are hashed to a maximum length of 72'
 time: 2023-04-12T13:25:01.113462+01:00
 custom:
   Issue: "397"

--- a/.changes/unreleased/BUG FIXES-20230412-132501.yaml
+++ b/.changes/unreleased/BUG FIXES-20230412-132501.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource/random_password: The `generateHash()` functions has been modified
+  to truncate strings to 72 bytes'
+time: 2023-04-12T13:25:01.113462+01:00
+custom:
+  Issue: "397"

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -53,7 +53,7 @@ resource "aws_db_instance" "example" {
 
 ### Read-Only
 
-- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random string.
+- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random string. **NOTE**: If the generated random string is greater than 72 bytes in length, `bcrypt_hash` will contain a hash of the first 72 bytes.
 - `id` (String) A static value used internally by Terraform, this should not be referenced in configurations.
 - `result` (String, Sensitive) The generated random string.
 

--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -537,10 +537,7 @@ func upgradePasswordStateV2toV3(ctx context.Context, req resource.UpgradeStateRe
 
 // generateHash truncates strings that are longer than 72 bytes in
 // order to avoid the error returned from bcrypt.GenerateFromPassword
-// in versions v0.5.0 and above (refer to
-// https://pkg.go.dev/golang.org/x/crypto/bcrypt?tab=versions).
-// This is to preserve backwards compatibility and will be removed in
-// a subsequent version of the provider.
+// in versions v0.5.0 and above: https://pkg.go.dev/golang.org/x/crypto@v0.8.0/bcrypt#GenerateFromPassword
 func generateHash(toHash string) (string, error) {
 	bytesHash := []byte(toHash)
 	bytesToHash := bytesHash

--- a/internal/provider/resource_password.go
+++ b/internal/provider/resource_password.go
@@ -706,9 +706,11 @@ func passwordSchemaV3() schema.Schema {
 			},
 
 			"bcrypt_hash": schema.StringAttribute{
-				Description: "A bcrypt hash of the generated random string.",
-				Computed:    true,
-				Sensitive:   true,
+				Description: "A bcrypt hash of the generated random string. " +
+					"**NOTE**: If the generated random string is greater than 72 bytes in length, " +
+					"`bcrypt_hash` will contain a hash of the first 72 bytes.",
+				Computed:  true,
+				Sensitive: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -818,9 +820,11 @@ func passwordSchemaV2() schema.Schema {
 			},
 
 			"bcrypt_hash": schema.StringAttribute{
-				Description: "A bcrypt hash of the generated random string.",
-				Computed:    true,
-				Sensitive:   true,
+				Description: "A bcrypt hash of the generated random string. " +
+					"**NOTE**: If the generated random string is greater than 72 bytes in length, " +
+					"`bcrypt_hash` will contain a hash of the first 72 bytes.",
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"id": schema.StringAttribute{
@@ -916,9 +920,11 @@ func passwordSchemaV1() schema.Schema {
 			},
 
 			"bcrypt_hash": schema.StringAttribute{
-				Description: "A bcrypt hash of the generated random string.",
-				Computed:    true,
-				Sensitive:   true,
+				Description: "A bcrypt hash of the generated random string. " +
+					"**NOTE**: If the generated random string is greater than 72 bytes in length, " +
+					"`bcrypt_hash` will contain a hash of the first 72 bytes.",
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"id": schema.StringAttribute{

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -28,7 +28,7 @@ func TestGenerateHash(t *testing.T) {
 	}{
 		"defaults": {
 			input: random.StringParams{
-				Length:  32, // Required
+				Length:  73, // Required
 				Lower:   true,
 				Numeric: true,
 				Special: true,
@@ -111,7 +111,7 @@ func TestAccResourcePassword_BcryptHash(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "random_password" "test" {
-							length = 12
+							length = 73
 						}`,
 				Check: resource.ComposeTestCheckFunc(
 					testExtractResourceAttr("random_password.test", "bcrypt_hash", &bcryptHash),


### PR DESCRIPTION
Closes: #396 

This PR replicates the behaviour of the `bcrypt` package in versions of [golang.org/x/crypto](https://pkg.go.dev/golang.org/x/crypto/bcrypt?tab=versions) prior to `v0.5.0`. 