### PR TITLE
docs: Add explicit note of cryptographic generator to `random_bytes`

### DIFF
--- a/docs/resources/bytes.md
+++ b/docs/resources/bytes.md
@@ -4,11 +4,14 @@ page_title: "random_bytes Resource - terraform-provider-random"
 subcategory: ""
 description: |-
   The resource random_bytes generates random bytes that are intended to be used as a secret, or key. Use this in preference to random_id when the output is considered sensitive, and should not be displayed in the CLI.
+  This resource does use a cryptographic random number generator.
 ---
 
 # random_bytes (Resource)
 
 The resource `random_bytes` generates random bytes that are intended to be used as a secret, or key. Use this in preference to `random_id` when the output is considered sensitive, and should not be displayed in the CLI.
+
+This resource *does* use a cryptographic random number generator.
 
 ## Example Usage
 

--- a/internal/provider/resource_bytes.go
+++ b/internal/provider/resource_bytes.go
@@ -135,7 +135,9 @@ func bytesSchemaV0() schema.Schema {
 		Version: 0,
 		Description: "The resource `random_bytes` generates random bytes that are intended to be " +
 			"used as a secret, or key. Use this in preference to `random_id` when the output is " +
-			"considered sensitive, and should not be displayed in the CLI.",
+			"considered sensitive, and should not be displayed in the CLI.\n" +
+			"\n" +
+			"This resource *does* use a cryptographic random number generator.",
 		Attributes: map[string]schema.Attribute{
 			"keepers": schema.MapAttribute{
 				Description: "Arbitrary map of values that, when changed, will trigger recreation of " +


### PR DESCRIPTION
Closes #528 