### PR TITLE
resource/random_shuffle: Prevent inconsistent result after apply when result_count is set to 0

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240226-103821.yaml
+++ b/.changes/unreleased/BUG FIXES-20240226-103821.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource/random_shuffle: Prevent inconsistent result after apply when result_count
+  is set to 0'
+time: 2024-02-26T10:38:21.636994-05:00
+custom:
+  Issue: "409"

--- a/docs/resources/shuffle.md
+++ b/docs/resources/shuffle.md
@@ -45,4 +45,4 @@ resource "aws_elb" "example" {
 ### Read-Only
 
 - `id` (String) A static value used internally by Terraform, this should not be referenced in configurations.
-- `result` (List of String) Random permutation of the list of strings given in `input`.
+- `result` (List of String) Random permutation of the list of strings given in `input`. The number of elements is determined by `result_count` if set, or the number of elements in `input`.

--- a/internal/provider/resource_shuffle_test.go
+++ b/internal/provider/resource_shuffle_test.go
@@ -787,7 +787,27 @@ func TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValueToValue(t *te
 	})
 }
 
-func TestAccResourceShuffle_Shorter(t *testing.T) {
+// Reference: https://github.com/hashicorp/terraform-provider-random/issues/409
+func TestAccResourceShuffle_ResultCount_Zero(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "random_shuffle" "test" {
+    						input        = ["a", "b", "c", "d", "e"]
+    						result_count = 0
+						}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("random_shuffle.test", "result.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceShuffle_ResultCount_Shorter(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -808,7 +828,7 @@ func TestAccResourceShuffle_Shorter(t *testing.T) {
 	})
 }
 
-func TestAccResourceShuffle_Longer(t *testing.T) {
+func TestAccResourceShuffle_ResultCount_Longer(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -838,7 +858,7 @@ func TestAccResourceShuffle_Longer(t *testing.T) {
 	})
 }
 
-func TestAccResourceShuffle_Empty(t *testing.T) {
+func TestAccResourceShuffle_Input_Empty(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -856,7 +876,7 @@ func TestAccResourceShuffle_Empty(t *testing.T) {
 	})
 }
 
-func TestAccResourceShuffle_One(t *testing.T) {
+func TestAccResourceShuffle_Input_One(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Closes #409

Previously, Terraform would return an error because the configuration value for `result_count` was overwritten during resource creation.

```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to random_shuffle.test, provider
│ "provider[\"registry.terraform.io/hashicorp/random\"]" produced an unexpected new value:
│ .result_count: was cty.NumberIntVal(0), but now cty.NumberIntVal(2).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

This change will cause the resource creation to not modify any configuration value data and also return early with an empty list for `result` if `result_count` is explicitly configured as `0` or if `input` has no elements.

Output from acceptance testing:

```console
$ TF_ACC=1 go test -count=1 -run='TestAccResourceShuffle_' -timeout=10m -v ./internal/provider
=== RUN   TestAccResourceShuffle_Keepers_Keep_EmptyMap
=== PAUSE TestAccResourceShuffle_Keepers_Keep_EmptyMap
=== RUN   TestAccResourceShuffle_Keepers_Keep_EmptyMapToNullValue
=== PAUSE TestAccResourceShuffle_Keepers_Keep_EmptyMapToNullValue
=== RUN   TestAccResourceShuffle_Keepers_Keep_NullMap
=== PAUSE TestAccResourceShuffle_Keepers_Keep_NullMap
=== RUN   TestAccResourceShuffle_Keepers_Keep_NullMapToNullValue
=== PAUSE TestAccResourceShuffle_Keepers_Keep_NullMapToNullValue
=== RUN   TestAccResourceShuffle_Keepers_Keep_NullValue
=== PAUSE TestAccResourceShuffle_Keepers_Keep_NullValue
=== RUN   TestAccResourceShuffle_Keepers_Keep_NullValues
=== PAUSE TestAccResourceShuffle_Keepers_Keep_NullValues
=== RUN   TestAccResourceShuffle_Keepers_Keep_Value
=== PAUSE TestAccResourceShuffle_Keepers_Keep_Value
=== RUN   TestAccResourceShuffle_Keepers_Keep_Values
=== PAUSE TestAccResourceShuffle_Keepers_Keep_Values
=== RUN   TestAccResourceShuffle_Keepers_Replace_EmptyMapToValue
=== PAUSE TestAccResourceShuffle_Keepers_Replace_EmptyMapToValue
=== RUN   TestAccResourceShuffle_Keepers_Replace_NullMapToValue
=== PAUSE TestAccResourceShuffle_Keepers_Replace_NullMapToValue
=== RUN   TestAccResourceShuffle_Keepers_Replace_NullValueToValue
=== PAUSE TestAccResourceShuffle_Keepers_Replace_NullValueToValue
=== RUN   TestAccResourceShuffle_Keepers_Replace_ValueToEmptyMap
=== PAUSE TestAccResourceShuffle_Keepers_Replace_ValueToEmptyMap
=== RUN   TestAccResourceShuffle_Keepers_Replace_ValueToNullMap
=== PAUSE TestAccResourceShuffle_Keepers_Replace_ValueToNullMap
=== RUN   TestAccResourceShuffle_Keepers_Replace_ValueToNullValue
=== PAUSE TestAccResourceShuffle_Keepers_Replace_ValueToNullValue
=== RUN   TestAccResourceShuffle_Keepers_Replace_ValueToNewValue
=== PAUSE TestAccResourceShuffle_Keepers_Replace_ValueToNewValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToNullValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToNullValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleNullValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleNullValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValue
=== RUN   TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValueToValue
=== PAUSE TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValueToValue
=== RUN   TestAccResourceShuffle_ResultCount_Zero
=== PAUSE TestAccResourceShuffle_ResultCount_Zero
=== RUN   TestAccResourceShuffle_ResultCount_Shorter
--- PASS: TestAccResourceShuffle_ResultCount_Shorter (2.51s)
=== RUN   TestAccResourceShuffle_ResultCount_Longer
--- PASS: TestAccResourceShuffle_ResultCount_Longer (0.50s)
=== RUN   TestAccResourceShuffle_Input_Empty
--- PASS: TestAccResourceShuffle_Input_Empty (0.50s)
=== RUN   TestAccResourceShuffle_Input_One
--- PASS: TestAccResourceShuffle_Input_One (0.49s)
=== RUN   TestAccResourceShuffle_UpgradeFromVersion3_3_2
--- PASS: TestAccResourceShuffle_UpgradeFromVersion3_3_2 (20.27s)
=== CONT  TestAccResourceShuffle_Keepers_Keep_EmptyMap
=== CONT  TestAccResourceShuffle_Keepers_Replace_ValueToEmptyMap
=== CONT  TestAccResourceShuffle_Keepers_Keep_Value
=== CONT  TestAccResourceShuffle_Keepers_Keep_NullMapToNullValue
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleNullValue
=== CONT  TestAccResourceShuffle_ResultCount_Zero
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValueToValue
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValue
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleValue
=== CONT  TestAccResourceShuffle_Keepers_Keep_NullMap
--- PASS: TestAccResourceShuffle_ResultCount_Zero (0.68s)
=== CONT  TestAccResourceShuffle_Keepers_Keep_NullValues
--- PASS: TestAccResourceShuffle_Keepers_Keep_Value (1.07s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_ValueToNewValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_NullMap (1.08s)
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_EmptyMap (1.08s)
=== CONT  TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToNullValue
--- PASS: TestAccResourceShuffle_Keepers_Replace_ValueToEmptyMap (1.14s)
=== CONT  TestAccResourceShuffle_Keepers_Keep_NullValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_NullMapToNullValue (1.20s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_NullMapToValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_NullValues (0.96s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_NullValueToValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_NullValue (0.86s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_ValueToNullValue
--- PASS: TestAccResourceShuffle_Keepers_Replace_ValueToNewValue (0.97s)
=== CONT  TestAccResourceShuffle_Keepers_Keep_Values
--- PASS: TestAccResourceShuffle_Keepers_Replace_NullMapToValue (0.94s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_ValueToNullMap
--- PASS: TestAccResourceShuffle_Keepers_Replace_NullValueToValue (0.93s)
=== CONT  TestAccResourceShuffle_Keepers_Keep_EmptyMapToNullValue
--- PASS: TestAccResourceShuffle_Keepers_Replace_ValueToNullValue (0.96s)
=== CONT  TestAccResourceShuffle_Keepers_Replace_EmptyMapToValue
--- PASS: TestAccResourceShuffle_Keepers_Keep_Values (0.92s)
--- PASS: TestAccResourceShuffle_Keepers_Replace_ValueToNullMap (0.96s)
--- PASS: TestAccResourceShuffle_Keepers_Keep_EmptyMapToNullValue (0.91s)
--- PASS: TestAccResourceShuffle_Keepers_Replace_EmptyMapToValue (0.86s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleNullValue (16.50s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToMultipleValue (17.15s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValue (17.83s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapValueToValue (18.49s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToValue (29.52s)
--- PASS: TestAccResourceShuffle_Keepers_FrameworkMigration_NullMapToNullValue (30.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-random/internal/provider      59.548s
```