### PR TITLE
Error handling: Check that char set is not empty

### DIFF
--- a/internal/provider/resource_string_test.go
+++ b/internal/provider/resource_string_test.go
@@ -894,6 +894,24 @@ func TestAccResourceString_Min(t *testing.T) {
 	})
 }
 
+func TestAccResourceString_ErrorsOnNoCharset(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "random_string" "nochars" {
+							length = 16
+							lower = false
+							upper = false
+							special = false
+							numeric = false
+						}`,
+				ExpectError: regexp.MustCompile(`.*Random Read Error`),
+			},
+		},
+	})
+}
+
 // TestAccResourceString_StateUpgradeV1toV2 covers the state upgrade from V1 to V2.
 // This includes the deprecation of `number` and the addition of `numeric` attributes.
 // v3.2.0 was used as this is the last version before `number` was deprecated and `numeric` attribute

--- a/internal/random/string.go
+++ b/internal/random/string.go
@@ -5,6 +5,7 @@ package random
 
 import (
 	"crypto/rand"
+	"errors"
 	"math/big"
 	"sort"
 )
@@ -86,6 +87,9 @@ func CreateString(input StringParams) ([]byte, error) {
 func generateRandomBytes(charSet *string, length int64) ([]byte, error) {
 	bytes := make([]byte, length)
 	setLen := big.NewInt(int64(len(*charSet)))
+	if setLen.Sign() <= 0 {
+		return bytes, errors.New("no char set to generate from: cannot set all char sets to false")
+	}
 	for i := range bytes {
 		idx, err := rand.Int(rand.Reader, setLen)
 		if err != nil {


### PR DESCRIPTION
fix: return error instead of panic when charset winds up empty. Add test.

Fixes https://github.com/hashicorp/terraform-provider-random/issues/549.