### PR TITLE
resource/random_password: Fix testing for Terraform 1.8 non-refresh handling

### DIFF
--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"golang.org/x/crypto/bcrypt"
 
@@ -382,13 +383,11 @@ func TestAccResourcePassword_Import_FromVersion3_1_3(t *testing.T) {
 				Config: `resource "random_password" "test" {
 					length = 12
 				}`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `resource "random_password" "test" {
-							length = 12
-						}`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_password.test", "result", testCheckLen(12)),
 					resource.TestCheckResourceAttr("random_password.test", "number", "true"),

--- a/internal/provider/resource_password_test.go
+++ b/internal/provider/resource_password_test.go
@@ -1000,18 +1000,11 @@ func TestAccResourcePassword_UpgradeFromVersion2_2_1(t *testing.T) {
 							min_special = 1
 							min_numeric = 4
 						}`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `resource "random_password" "min" {
-							length = 12
-							override_special = "!#@"
-							min_lower = 2
-							min_upper = 3
-							min_special = 1
-							min_numeric = 4
-						}`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_password.min", "result", testCheckLen(12)),
 					resource.TestMatchResourceAttr("random_password.min", "result", regexp.MustCompile(`([a-z].*){2,}`)),


### PR DESCRIPTION
Reference: https://developer.hashicorp.com/terraform/language/v1.8.x/upgrade-guides#possible-spurious-changes-when-refreshing

Previously the `TestAccResourcePassword_Import_FromVersion3_1_3` acceptance test used `PlanOnly: true` which ran a non-refresh plan as its first step. After Terraform 1.8, additional attribute sensitivity metadata is saved into the state, which can cause a non-refresh plan difference and break the acceptance test:

```
=== CONT  TestAccResourcePassword_Import_FromVersion3_1_3
    resource_password_test.go:357: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # random_password.test will be updated in-place
          ~ resource "random_password" "test" {
                id          = "none"
                # (12 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:626: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for random_password.test in state does not match version 3 from the provider
--- FAIL: TestAccResourcePassword_Import_FromVersion3_1_3 (1.71s)
```

Adjusting this acceptance test to replace `PlanOnly: true` with `plancheck.ExpectNoChanges()` covers the same desired behavior along with the more-common practitioner behavior of refresh plans rather than non-refresh plans after provider upgrades.