### PR TITLE
Update CHANGELOG for #581

### DIFF
--- a/.changes/unreleased/NOTES-20240521-152522.yaml
+++ b/.changes/unreleased/NOTES-20240521-152522.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'resource/random_pet: Results have been updated to the latest upstream petname data'
+time: 2024-05-21T15:25:22.081016-04:00
+custom:
+    Issue: "581"


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-random/pull/581

So we can cut a v3.6.2 release with at least some changelog entry.