### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240910-073526.yaml
+++ b/.changes/unreleased/NOTES-20240910-073526.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: This release introduces no functional changes. It does however include
+  dependency updates which address upstream CVEs.'
+time: 2024-09-10T07:35:26.094054-04:00
+custom:
+  Issue: "604"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The remainder of this document will focus on the development aspects of the prov
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads) (>= 0.12)
-* [Go](https://go.dev/doc/install) (1.21)
+* [Go](https://go.dev/doc/install) (1.22)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/terraform-providers/terraform-provider-random
 
-go 1.21
-
-toolchain go1.21.3
+go 1.22.7
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7