### PR TITLE
docs: Adjust write-only wording to favor argument over attribute

### DIFF
--- a/docs/ephemeral-resources/password.md
+++ b/docs/ephemeral-resources/password.md
@@ -3,18 +3,18 @@
 page_title: "random_password Ephemeral Resource - terraform-provider-random"
 subcategory: ""
 description: |-
-  -> If the managed resource doesn't have a write-only attribute available for the password (first introduced in Terraform 1.11), then the password can only be created with the managed resource variant of random_password https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password.
+  -> If the managed resource doesn't have a write-only argument available for the password (first introduced in Terraform 1.11), then the password can only be created with the managed resource variant of random_password https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password.
   Generates an ephemeral password string using a cryptographic random number generator.
-  The primary use-case for generating an ephemeral random password is to be used in combination with a write-only attribute in a managed resource, which will avoid Terraform storing the password string in the plan or state file.
+  The primary use-case for generating an ephemeral random password is to be used in combination with a write-only argument in a managed resource, which will avoid Terraform storing the password string in the plan or state file.
 ---
 
 # random_password (Ephemeral Resource)
 
--> If the managed resource doesn't have a write-only attribute available for the password (first introduced in Terraform 1.11), then the password can only be created with the managed resource variant of [`random_password`](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password).
+-> If the managed resource doesn't have a write-only argument available for the password (first introduced in Terraform 1.11), then the password can only be created with the managed resource variant of [`random_password`](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password).
 
 Generates an ephemeral password string using a cryptographic random number generator.
 
-The primary use-case for generating an ephemeral random password is to be used in combination with a write-only attribute in a managed resource, which will avoid Terraform storing the password string in the plan or state file.
+The primary use-case for generating an ephemeral random password is to be used in combination with a write-only argument in a managed resource, which will avoid Terraform storing the password string in the plan or state file.
 
 ## Example Usage
 

--- a/internal/provider/ephemeral_password.go
+++ b/internal/provider/ephemeral_password.go
@@ -48,12 +48,12 @@ func (e *passwordEphemeralResource) Metadata(ctx context.Context, req ephemeral.
 
 func (e *passwordEphemeralResource) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "-> If the managed resource doesn't have a write-only attribute available for the password (first introduced in Terraform 1.11), then the " +
+		Description: "-> If the managed resource doesn't have a write-only argument available for the password (first introduced in Terraform 1.11), then the " +
 			"password can only be created with the managed resource variant of [`random_password`](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password).\n" +
 			"\n" +
 			"Generates an ephemeral password string using a cryptographic random number generator.\n" +
 			"\n" +
-			"The primary use-case for generating an ephemeral random password is to be used in combination with a write-only attribute " +
+			"The primary use-case for generating an ephemeral random password is to be used in combination with a write-only argument " +
 			"in a managed resource, which will avoid Terraform storing the password string in the plan or state file.",
 		Attributes: map[string]schema.Attribute{
 			"length": schema.Int64Attribute{


### PR DESCRIPTION
Follow-up doc fix to #625 