### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@
 # (metadata.json) -- and a Terraform Registry manifest file (terraform-registry-manifest.json).
 #
 # Reference: https://github.com/hashicorp/terraform-provider-crt-example/blob/main/.github/workflows/README.md
-#
-# TODO comments are provided to guide you through customizing this workflow for your provider.
 
 name: build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      # TODO: Customize `matrix` for your provider. Compare to existing .goreleaser.yml.
       # Verify expected Artifacts list for a workflow run.
       matrix:
         goos: [freebsd, windows, linux, darwin]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: hashicorp/actions-go-build@v1
-        # TODO: Customize `env` for your provider build. Compare to existing .goreleaser.yml.
         env:
           CGO_ENABLED: 0
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
               -o "$BIN_PATH" \
               -trimpath \
               -buildvcs=false \
-              -ldflags "-s -w -X 'main.version=${{ needs.set-product-version.outputs.product-version }}'"
+              -ldflags "-s -w"
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
 
   whats-next:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,6 @@ jobs:
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
         with:
-          # TODO: Customize `bin_name` for your provider. Compare to existing .goreleaser.yml.
-          # Protocol v6 providers should omit the `_x5` suffix.
           bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
+# This workflow builds the product for all supported platforms and uploads the resulting
+# binaries as Actions artifacts. The workflow also uploads a build metadata file
+# (metadata.json) -- and a Terraform Registry manifest file (terraform-registry-manifest.json).
+#
+# Reference: https://github.com/hashicorp/terraform-provider-crt-example/blob/main/.github/workflows/README.md
+#
+# TODO comments are provided to guide you through customizing this workflow for your provider.
+
 name: build
 
-# We now default to running this workflow on every push to every branch.
+# We default to running this workflow on every push to every branch.
 # This provides fast feedback when build issues occur, so they can be
 # fixed prior to being merged to the main branch.
 #
@@ -12,12 +20,14 @@ name: build
 on: [workflow_dispatch, push]
 
 env:
-  PKG_NAME: "terraform-provider-random"
+  PKG_NAME: "terraform-provider-crt-example" # TODO: Update with the name of your provider
 
 jobs:
+  # Detects the Go toolchain version to use for product builds.
+  #
+  # The implementation is inspired by envconsul -- https://go.hashi.co/get-go-version-example
   get-go-version:
-    # Inspired by envconsul -- https://github.com/hashicorp/envconsul/blob/bcb270fdc53e1273b3010d51c02fcf2e67d830d0/.github/workflows/build.yml#L18
-    name: "Determine Go toolchain version"
+    name: "Detect Go toolchain version"
     runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
@@ -26,13 +36,19 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-      - name: Determine Go version
+      - name: Detect Go version
         id: get-go-version
         run: |
-          echo "Building with Go $(go env GOVERSION | tr -d 'go')"
-          echo "go-version=$(go env GOVERSION | tr -d 'go')" >> "$GITHUB_OUTPUT"
+          version="$(go list -f {{.GoVersion}} -m)"
+          echo "go-version=$version" >> "$GITHUB_OUTPUT"
 
+  # Parses the version/VERSION file. Reference: https://github.com/hashicorp/actions-set-product-version/blob/main/README.md
+  #
+  # > This action should be implemented in product repo `build.yml` files. The action is intended to grab the version
+  # > from the version file at the beginning of the build, then passes those versions (along with metadata, where
+  # > necessary) to any workflow jobs that need version information.
   set-product-version:
+    name: "Parse version file"
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
@@ -41,10 +57,13 @@ jobs:
       product-minor-version: ${{ steps.set-product-version.outputs.minor-product-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set Product version
+      - name: Set variables
         id: set-product-version
         uses: hashicorp/actions-set-product-version@v2
 
+  # Creates metadata.json file containing build metadata for consumption by CRT workflows.
+  #
+  # Reference: https://github.com/hashicorp/actions-generate-metadata/blob/main/README.md
   generate-metadata-file:
     needs: set-product-version
     runs-on: ubuntu-latest
@@ -65,15 +84,53 @@ jobs:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  build-other:
+  # Uploads an Actions artifact named terraform-registry-manifest.json.zip.
+  #
+  # The artifact contains a single file with a filename that Terraform Registry expects
+  # (example: terraform-provider-crt-example_2.3.6-alpha1_manifest.json). The file contents
+  # are identical to the terraform-registry-manifest.json file in the source repository.
+  upload-terraform-registry-manifest-artifact:
+    needs: set-product-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout directory"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: ${{ env.PKG_NAME }}
+      - name: "Copy manifest from checkout directory to a file with the desired name"
+        id: terraform-registry-manifest
+        run: |
+          name="${{ env.PKG_NAME }}"
+          version="${{ needs.set-product-version.outputs.product-version }}"
+
+          source="${name}/terraform-registry-manifest.json"
+          destination="${name}_${version}_manifest.json"
+
+          cp "$source" "$destination"
+          echo "filename=$destination" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: terraform-registry-manifest.json
+          path: ${{ steps.terraform-registry-manifest.outputs.filename }}
+          if-no-files-found: error
+
+  # Builds the product for all platforms except macOS.
+  #
+  # With `reproducible: report`, this job also reports whether the build is reproducible,
+  # but does not enforce it.
+  #
+  # Reference: https://github.com/hashicorp/actions-go-build/blob/main/README.md
+  build:
     needs:
       - get-go-version
       - set-product-version
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # recommended during development
+      fail-fast: true
+      # TODO: Customize `matrix` for your provider. Compare to existing .goreleaser.yml.
+      # Verify expected Artifacts list for a workflow run.
       matrix:
-        goos: [freebsd, windows, linux]
+        goos: [freebsd, windows, linux, darwin]
         goarch: ["386", "amd64", "arm", "arm64"]
         exclude:
           - goos: freebsd
@@ -82,17 +139,24 @@ jobs:
             goarch: arm64
           - goos: windows
             goarch: arm
+          - goos: darwin
+            goarch: 386
+          - goos: darwin
+            goarch: arm
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: hashicorp/actions-go-build@v1
+        # TODO: Customize `env` for your provider build. Compare to existing .goreleaser.yml.
         env:
           CGO_ENABLED: 0
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
         with:
+          # TODO: Customize `bin_name` for your provider. Compare to existing .goreleaser.yml.
+          # Protocol v6 providers should omit the `_x5` suffix.
           bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
@@ -100,48 +164,32 @@ jobs:
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
           reproducible: report
+          # TODO: Customize `go build` flags for your provider. Compare to existing .goreleaser.yml.
+          # TODO: Customize `ldflags` for your provider. Ensure that the import path and name in the -X flag
+          # are correct for your provider.
           instructions: |
             go build \
               -o "$BIN_PATH" \
               -trimpath \
               -buildvcs=false \
-              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
+              -ldflags "-s -w -X 'main.version=${{ needs.set-product-version.outputs.product-version }}'"
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
 
-  build-darwin:
+  whats-next:
     needs:
-      - get-go-version
-      - set-product-version
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        goos: [darwin]
-        goarch: ["amd64", "arm64"]
-      fail-fast: true
-    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
+      - build
+      - generate-metadata-file
+      - upload-terraform-registry-manifest-artifact
+    runs-on: ubuntu-latest
+    name: "What's next?"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: hashicorp/actions-go-build@v1
-        env:
-          CGO_ENABLED: 0
-          BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
-          PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
-          METADATA_VERSION: ${{ env.METADATA }}
-        with:
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
-          product_name: ${{ env.PKG_NAME }}
-          product_version: ${{ needs.set-product-version.outputs.product-version }}
-          go_version: ${{ needs.get-go-version.outputs.go-version }}
-          os: ${{ matrix.goos }}
-          arch: ${{ matrix.goarch }}
-          reproducible: report
-          instructions: |
-            go build \
-              -o "$BIN_PATH" \
-              -trimpath \
-              -buildvcs=false \
-              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
-            cp LICENSE "$TARGET_DIR/LICENSE.txt"
+      - name: "Write a helpful summary"
+        run: |
+          github_dot_com="${{ github.server_url }}"
+          owner_with_name="${{ github.repository }}"
+          ref="${{ github.ref }}"
+
+          echo "### What's next?" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### For a release branch (see \`.release/ci.hcl\`)" >> $GITHUB_STEP_SUMMARY
+          echo "After this \`build\` workflow run completes succesfully, you can expect the CRT \`prepare\` workflow to begin momentarily." >> "$GITHUB_STEP_SUMMARY"
+          echo "To find the \`prepare\` workflow run, [view the checks for this commit]($github_dot_com/$owner_with_name/commits/$ref)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,9 +158,6 @@ jobs:
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
           reproducible: report
-          # TODO: Customize `go build` flags for your provider. Compare to existing .goreleaser.yml.
-          # TODO: Customize `ldflags` for your provider. Ensure that the import path and name in the -X flag
-          # are correct for your provider.
           instructions: |
             go build \
               -o "$BIN_PATH" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ name: build
 on: [workflow_dispatch, push]
 
 env:
-  PKG_NAME: "terraform-provider-crt-example" # TODO: Update with the name of your provider
+  PKG_NAME: "terraform-provider-random"
 
 jobs:
   # Detects the Go toolchain version to use for product builds.


### PR DESCRIPTION
We've made big updates to the build.yml reference example for Terraform providers.

The most critical change is the new
`upload-terraform-registry-manifest-artifact` job. This is necessary for correctness of publishing providers to Terraform Registry.

I open this pull request as a convenient way of notifying your team of this change. In terraform-provider-cloudinit and terraform-provider-null, I have completely replaced the existing build.yml with this new version -- that is the simplest upgrade path.

Review and change the defaults as needed. Follow the TODO comments for step-by-step guidance.