### PR TITLE
chore: release `v3.8.1` prep

### DIFF
--- a/.changes/3.8.1.md
+++ b/.changes/3.8.1.md
@@ -1,0 +1,6 @@
+## 3.8.1 (January 27, 2026)
+
+NOTES:
+
+* This release introduces no functional changes but has been signed with a valid certificate for the windows binary. ([#749](https://github.com/hashicorp/terraform-provider-random/issues/749))
+

--- a/.changes/unreleased/NOTES-20260127-155919.yaml
+++ b/.changes/unreleased/NOTES-20260127-155919.yaml
@@ -1,5 +1,0 @@
-kind: NOTES
-body: This release introduces no functional changes but has been signed with a valid certificate for the windows binary.
-time: 2026-01-27T15:59:19.408302+01:00
-custom:
-    Issue: "749"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.8.1 (January 27, 2026)
+
+NOTES:
+
+* This release introduces no functional changes but has been signed with a valid certificate for the windows binary. ([#749](https://github.com/hashicorp/terraform-provider-random/issues/749))
+
 ## 3.8.0 (January 12, 2026)
 
 ENHANCEMENTS:


### PR DESCRIPTION
## Description

Patch release for having a signed windows binary.

Closes #749 
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None.