### PR TITLE
Update go to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-random
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0


### PR DESCRIPTION
## Description

Updates the go standard library to addresses GO-2026-4337, but the provider should not be affected by this vulnerability. This will help appease security scanning tools (Ref: PSA-2663).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None