### PR TITLE
[documentation] replace references to strings with "password" where appropriate for password.md files

### DIFF
--- a/docs/ephemeral-resources/password.md
+++ b/docs/ephemeral-resources/password.md
@@ -31,7 +31,7 @@ ephemeral "random_password" "password" {
 
 ### Required
 
-- `length` (Number) The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).
+- `length` (Number) The length of the password desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).
 
 ### Optional
 
@@ -41,11 +41,11 @@ ephemeral "random_password" "password" {
 - `min_special` (Number) Minimum number of special characters in the result. Default value is `0`.
 - `min_upper` (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
 - `numeric` (Boolean) Include numeric characters in the result. Default value is `true`. If `numeric`, `upper`, `lower`, and `special` are all configured, at least one of them must be set to `true`.
-- `override_special` (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
+- `override_special` (String) Supply your own list of special characters to use for password generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
 - `special` (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.
 - `upper` (Boolean) Include uppercase alphabet characters in the result. Default value is `true`.
 
 ### Read-Only
 
-- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random string. **NOTE**: If the generated random string is greater than 72 bytes in length, `bcrypt_hash` will contain a hash of the first 72 bytes.
-- `result` (String, Sensitive) The generated random string.
+- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random password. **NOTE**: If the generated random password is greater than 72 bytes in length, `bcrypt_hash` will contain a hash of the first 72 bytes.
+- `result` (String, Sensitive) The generated random password.

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -38,7 +38,7 @@ resource "aws_db_instance" "example" {
 
 ### Required
 
-- `length` (Number) The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).
+- `length` (Number) The length of the password desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).
 
 ### Optional
 
@@ -50,15 +50,15 @@ resource "aws_db_instance" "example" {
 - `min_upper` (Number) Minimum number of uppercase alphabet characters in the result. Default value is `0`.
 - `number` (Boolean, Deprecated) Include numeric characters in the result. Default value is `true`. If `number`, `upper`, `lower`, and `special` are all configured, at least one of them must be set to `true`. **NOTE**: This is deprecated, use `numeric` instead.
 - `numeric` (Boolean) Include numeric characters in the result. Default value is `true`. If `numeric`, `upper`, `lower`, and `special` are all configured, at least one of them must be set to `true`.
-- `override_special` (String) Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
+- `override_special` (String) Supply your own list of special characters to use for password generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.
 - `special` (Boolean) Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.
 - `upper` (Boolean) Include uppercase alphabet characters in the result. Default value is `true`.
 
 ### Read-Only
 
-- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random string. **NOTE**: If the generated random string is greater than 72 bytes in length, `bcrypt_hash` will contain a hash of the first 72 bytes.
+- `bcrypt_hash` (String, Sensitive) A bcrypt hash of the generated random password. **NOTE**: If the generated random password is greater than 72 bytes in length, `bcrypt_hash` will contain a hash of the first 72 bytes.
 - `id` (String) A static value used internally by Terraform, this should not be referenced in configurations.
-- `result` (String, Sensitive) The generated random string.
+- `result` (String, Sensitive) The generated random password.
 
 ## Import
 


### PR DESCRIPTION
## Related Issue

Fixes #796 

## Description

General clarity. I suspect 'password' was cloned from 'string' and these weren't updated.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

This is a change to documentation for secure/sensitive resources, so by all means treat this PR with extra scrutiny.
