### PR TITLE
suppress unused openpgp vulnerability

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -8,4 +8,15 @@ binary {
   osv          = true
   oss_index    = false
   nvd          = false
+
+  triage {
+    suppress {
+      vulnerabilities = [
+        // golang.org/x/crypto/openpgp is deprecated/unmaintained with no fixed
+        // version. The provider does not use this package (confirmed via
+        // `go mod why golang.org/x/crypto/openpgp`).
+        "GO-2026-5932",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Suppress `GO-2026-5932` in the release security scanner.
- The provider does not use `golang.org/x/crypto/openpgp`; `go mod why golang.org/x/crypto/openpgp` confirms there is no package dependency.
- The advisory has no fixed upstream version.

Assisted-by: OpenCode